### PR TITLE
added functionality needed for enqueuing

### DIFF
--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -2,15 +2,15 @@
 
 namespace Backpack\Base;
 
+use Backpack\Base\Traits\Enqueue;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use Route;
-use Backpack\Base\Traits\Enqueue;
 
 class BaseServiceProvider extends ServiceProvider
 {
     use Enqueue;
-    
+
     /**
      * Indicates if loading of the provider is deferred.
      *

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -5,9 +5,12 @@ namespace Backpack\Base;
 use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 use Route;
+use Backpack\Base\Traits\Enqueue;
 
 class BaseServiceProvider extends ServiceProvider
 {
+    use Enqueue;
+    
     /**
      * Indicates if loading of the provider is deferred.
      *

--- a/src/Traits/Enqueue.php
+++ b/src/Traits/Enqueue.php
@@ -5,11 +5,11 @@ namespace Backpack\Base\Traits;
 trait Enqueue
 {
     public static $enqueuedScripts = [];
-    public static $enqueuedStyles  = [];
+    public static $enqueuedStyles = [];
 
     public static function enqueueAsset($type, $id, $source, $dependencies = [])
     {
-        switch($type){
+        switch ($type) {
             case 'css':
             case 'style':
                 return self::enqueueStyle($id, $source, $dependencies);
@@ -24,19 +24,18 @@ trait Enqueue
 
     public static function enqueueScript($id, $source, $dependencies)
     {
-        if(!str_contains($source, "//")){
+        if (!str_contains($source, '//')) {
             $path = '/'.ltrim($source, '/');
-            $v = filemtime(realpath(ltrim($path, "/")));
+            $v = filemtime(realpath(ltrim($path, '/')));
             $sourceComputed = asset($path.'?v='.$v);
-        }
-        else {
+        } else {
             $sourceComputed = $source;
         }
 
         $sourceObj = (object) [
             'id'     => $id,
             'source' => $sourceComputed,
-            'deps'   => $dependencies
+            'deps'   => $dependencies,
         ];
 
         self::$enqueuedScripts[$id] = $sourceObj;
@@ -46,26 +45,24 @@ trait Enqueue
 
     public static function enqueueStyle($id, $source, $dependencies)
     {
-        if(!str_contains($source, "//")){
+        if (!str_contains($source, '//')) {
             $path = '/'.ltrim($source, '/');
-            $v = filemtime(realpath(ltrim($path, "/")));
+            $v = filemtime(realpath(ltrim($path, '/')));
             $sourceComputed = asset($path.'?v='.$v);
-        }
-        else {
+        } else {
             $sourceComputed = $source;
         }
 
         $sourceObj = (object) [
             'id'     => $id,
             'source' => $sourceComputed,
-            'deps'   => $dependencies
+            'deps'   => $dependencies,
         ];
 
         self::$enqueuedStyles[$id] = $sourceObj;
 
         return $sourceObj;
     }
-
 
     private static function handleDependencies($items)
     {
@@ -74,13 +71,13 @@ trait Enqueue
         $dependenciesFound = [];
         $circularDependencyCounter = 0;
 
-        while(count($items) > count($resolutions) && $circularDependencyCounter < 20) {
+        while (count($items) > count($resolutions) && $circularDependencyCounter < 20) {
             $circularDependencyCounter++;
 
-            foreach($items as $itemIndex => $item) {
+            foreach ($items as $itemIndex => $item) {
 
                 //If I'm an existing depdendency - skip me!
-                if(isset($dependenciesFound[$item->id])) {
+                if (isset($dependenciesFound[$item->id])) {
                     continue;
                 }
 
@@ -88,16 +85,16 @@ trait Enqueue
                 $resolved = true;
 
                 //Check through each depdendency to see if its alrady desolved
-                if(isset($item->deps) && !empty($item->deps)) {
-                    foreach($item->deps as $dep) {
-                        if(!isset($dependenciesFound[$dep])) {
+                if (isset($item->deps) && !empty($item->deps)) {
+                    foreach ($item->deps as $dep) {
+                        if (!isset($dependenciesFound[$dep])) {
                             $resolved = false;
                             break;
                         }
                     }
                 }
 
-                if($resolved) {
+                if ($resolved) {
                     $dependenciesFound[$item->id] = true;
                     $resolutions[] = $item;
                 }

--- a/src/Traits/Enqueue.php
+++ b/src/Traits/Enqueue.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Backpack\Base\Traits;
+
+trait Enqueue
+{
+    public static $enqueuedScripts = [];
+    public static $enqueuedStyles  = [];
+
+    public static function enqueueAsset($type, $id, $source, $dependencies = [])
+    {
+        switch($type){
+            case 'css':
+            case 'style':
+                return self::enqueueStyle($id, $source, $dependencies);
+                break;
+            case 'script':
+            case 'javascript':
+            case 'js':
+                return self::enqueueScript($id, $source, $dependencies);
+                break;
+        }
+    }
+
+    public static function enqueueScript($id, $source, $dependencies)
+    {
+        if(!str_contains($source, "//")){
+            $path = '/'.ltrim($source, '/');
+            $v = filemtime(realpath(ltrim($path, "/")));
+            $sourceComputed = asset($path.'?v='.$v);
+        }
+        else {
+            $sourceComputed = $source;
+        }
+
+        $sourceObj = (object) [
+            'id'     => $id,
+            'source' => $sourceComputed,
+            'deps'   => $dependencies
+        ];
+
+        self::$enqueuedScripts[$id] = $sourceObj;
+
+        return $sourceObj;
+    }
+
+    public static function enqueueStyle($id, $source, $dependencies)
+    {
+        if(!str_contains($source, "//")){
+            $path = '/'.ltrim($source, '/');
+            $v = filemtime(realpath(ltrim($path, "/")));
+            $sourceComputed = asset($path.'?v='.$v);
+        }
+        else {
+            $sourceComputed = $source;
+        }
+
+        $sourceObj = (object) [
+            'id'     => $id,
+            'source' => $sourceComputed,
+            'deps'   => $dependencies
+        ];
+
+        self::$enqueuedStyles[$id] = $sourceObj;
+
+        return $sourceObj;
+    }
+
+
+    private static function handleDependencies($items)
+    {
+        $items = array_unique($items, SORT_REGULAR); //Strip out duplicate requests
+        $resolutions = [];
+        $dependenciesFound = [];
+        $circularDependencyCounter = 0;
+
+        while(count($items) > count($resolutions) && $circularDependencyCounter < 20) {
+            $circularDependencyCounter++;
+
+            foreach($items as $itemIndex => $item) {
+
+                //If I'm an existing depdendency - skip me!
+                if(isset($dependenciesFound[$item->id])) {
+                    continue;
+                }
+
+                //We assume its found, unless stated below
+                $resolved = true;
+
+                //Check through each depdendency to see if its alrady desolved
+                if(isset($item->deps) && !empty($item->deps)) {
+                    foreach($item->deps as $dep) {
+                        if(!isset($dependenciesFound[$dep])) {
+                            $resolved = false;
+                            break;
+                        }
+                    }
+                }
+
+                if($resolved) {
+                    $dependenciesFound[$item->id] = true;
+                    $resolutions[] = $item;
+                }
+            }
+        }
+
+        return $resolutions;
+    }
+
+    public static function getScripts()
+    {
+        return self::handleDependencies(self::$enqueuedScripts);
+    }
+
+    public static function getStyles()
+    {
+        return self::handleDependencies(self::$enqueuedStyles);
+    }
+}

--- a/src/resources/views/layout.blade.php
+++ b/src/resources/views/layout.blade.php
@@ -30,6 +30,11 @@
     <!-- BackPack Base CSS -->
     <link rel="stylesheet" href="{{ asset('vendor/backpack/backpack.base.css') }}">
 
+    <!-- Enqueued CSS -->
+    @foreach( \Backpack\Base\BaseServiceProvider::getStyles() as $style )
+    <link rel="stylesheet" href="{{ $style->source }}" data-source-id="{{$style->id}}" data-deps="{{implode(',', $style->deps)}}">
+    @endforeach
+
     @yield('after_styles')
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -117,20 +122,24 @@
 
         // Ajax calls should always have the CSRF token attached to them, otherwise they won't work
         $.ajaxSetup({
-                headers: {
-                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
-                }
-            });
+            headers: {
+                'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+            }
+        });
 
         // Set active state on menu element
         var current_url = "{{ url(Route::current()->getUri()) }}";
         $("ul.sidebar-menu li a").each(function() {
-          if ($(this).attr('href').startsWith(current_url) || current_url.startsWith($(this).attr('href')))
-          {
-            $(this).parents('li').addClass('active');
-          }
+            if ($(this).attr('href').startsWith(current_url) || current_url.startsWith($(this).attr('href'))) {
+                $(this).parents('li').addClass('active');
+            }
         });
     </script>
+
+    <!-- Enqueued Scripts -->
+    @foreach( \Backpack\Base\BaseServiceProvider::getScripts() as $script )
+    <script src="{{ $script->source }}" data-source-id="{{$script->id}}" data-deps="{{implode(',', $script->deps)}}"></script>
+    @endforeach
 
     @include('backpack::inc.alerts')
 


### PR DESCRIPTION
Need guidance how best to actually implement this functionality.

**usage**

``` php
use \Backpack\Base\BaseServiceProvider as Backpack;

public function setUp()
{
    Backpack::enqueueAsset('css', 'blockui', '/css/blockui.css');

    Backpack::enqueueAsset('js', 'jquery-ui', '/js/jquery-ui.js', ['jquery']);
    Backpack::enqueueAsset('js', 'angular-sortable', '/js/ng-sortable.js', ['angular']);
    Backpack::enqueueAsset('js', 'angular', '/js/angular.js', ['jquery']);
    Backpack::enqueueAsset('js', 'blockui', '/js/blockui.js',['jquery']);
}
```

I've added the functionality needed for a project, which will also help developers who want to add non conflicting input types to their code, however I've implemented it as a Trait on the BaseServiceProvider - which I'm pretty sure is not the best way to do this, however I do not know how you're meant to do something like this in Laravel, so feedback on how to implement this feature correctly would be lovely :)
