### PR TITLE
Update ResetPasswordNotification.php

### DIFF
--- a/src/app/Notifications/ResetPasswordNotification.php
+++ b/src/app/Notifications/ResetPasswordNotification.php
@@ -13,7 +13,7 @@ class ResetPasswordNotification extends ResetPassword
      *
      * @return \Illuminate\Notifications\Messages\MailMessage
      */
-    public function toMail()
+    public function toMail($notifiable)
     {
         return (new MailMessage())
             ->line([


### PR DESCRIPTION
Parameter "$notifiable" is missing in toMail method.
Error report:
ErrorException in ResetPasswordNotification.php line 9:
Declaration of Backpack\Base\app\Notifications\ResetPasswordNotification::toMail()
should be compatible with Illuminate\Auth\Notifications\ResetPassword::toMail($notifiable)