### PR TITLE
Rename the Backpack Admin middleware to BackpackAdmin

### DIFF
--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -64,7 +64,7 @@ class BaseServiceProvider extends ServiceProvider
     public function setupRoutes(Router $router)
     {
         // register the 'admin' middleware
-        $router->middleware('admin', app\Http\Middleware\Admin::class);
+        $router->middleware('backpackadmin', app\Http\Middleware\BackpackAdmin::class);
 
         $router->group(['namespace' => 'Backpack\Base\app\Http\Controllers'], function ($router) {
             Route::group(

--- a/src/app/Http/Middleware/BackpackAdmin.php
+++ b/src/app/Http/Middleware/BackpackAdmin.php
@@ -5,7 +5,7 @@ namespace Backpack\Base\app\Http\Middleware;
 use Closure;
 use Illuminate\Support\Facades\Auth;
 
-class Admin
+class BackpackAdmin
 {
     /**
      * Handle an incoming request.


### PR DESCRIPTION
`Admin` is a common middleware name.  Backpack is forcing its middleware, named admin, into the `Admin` namespace.