### PR TITLE
Refactored LoginController, fixed paths handling, logout redirect

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -30,7 +30,7 @@ class LoginController extends Controller
      * @var string
      */
     protected $loginPath = 'admin/login';
-    
+
     /**
      * Redirect here after successful login.
      *

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -24,24 +24,23 @@ class LoginController extends Controller
         logout as defaultLogout;
     }
 
-    
     /**
      * If not logged in redirect here.
-     * 
+     *
      * @var string
      */
     protected $loginPath = 'admin/login';
     
     /**
      * Redirect here after successful login.
-     * 
+     *
      * @var string
      */
     protected $redirectTo = 'admin/dashboard';
 
     /**
      * Redirect here after logout.
-     * 
+     *
      * @var string
      */
     protected $redirectAfterLogout = 'admin';
@@ -56,7 +55,7 @@ class LoginController extends Controller
         $this->middleware('guest', ['except' => 'logout']);
 
         // Set up redirect paths if not specified
-        $this->loginPath = property_exists($this, 'loginPath') ? $this->loginPath 
+        $this->loginPath = property_exists($this, 'loginPath') ? $this->loginPath
             : config('backpack.base.route_prefix', 'admin').'/login';
 
         $this->redirectTo = property_exists($this, 'redirectTo') ? $this->redirectTo
@@ -85,7 +84,8 @@ class LoginController extends Controller
     /**
      * Log the user out and redirect him to specific location.
      *
-     * @param \Illuminate\Http\Request  $request
+     * @param \Illuminate\Http\Request $request
+     *
      * @return \Illuminate\Http\Response
      */
     public function logout(Request $request)

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -4,6 +4,7 @@ namespace Backpack\Base\app\Http\Controllers\Auth;
 
 use Backpack\Base\app\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request;
 
 class LoginController extends Controller
 {
@@ -19,18 +20,30 @@ class LoginController extends Controller
     | to conveniently provide its functionality to your applications.
     |
     */
-    use AuthenticatesUsers;
+    use AuthenticatesUsers {
+        logout as defaultLogout;
+    }
 
+    
     /**
-     * Where to redirect users after login / registration.
-     *
+     * If not logged in redirect here
+     * 
      * @var string
      */
-    // if not logged in redirect to
     protected $loginPath = 'admin/login';
-    // after you've logged in redirect to
+    
+    /**
+     * Redirect here after successful login
+     * 
+     * @var string
+     */
     protected $redirectTo = 'admin/dashboard';
-    // after you've logged out redirect to
+
+    /**
+     * Redirect here after logout
+     * 
+     * @var string
+     */
     protected $redirectAfterLogout = 'admin';
 
     /**
@@ -42,9 +55,15 @@ class LoginController extends Controller
     {
         $this->middleware('guest', ['except' => 'logout']);
 
-        $this->loginPath = config('backpack.base.route_prefix', 'admin').'/login';
-        $this->redirectTo = config('backpack.base.route_prefix', 'admin').'/dashboard';
-        $this->redirectAfterLogout = config('backpack.base.route_prefix', 'admin');
+        // Set up redirect paths if not specified
+        $this->loginPath = property_exists($this, 'loginPath') ? $this->loginPath 
+            : config('backpack.base.route_prefix', 'admin') . '/login';
+
+        $this->redirectTo = property_exists($this, 'redirectTo') ? $this->redirectTo
+            : config('backpack.base.route_prefix', 'admin') . '/dashboard';
+
+        $this->redirectAfterLogout = property_exists($this, 'redirectAfterLogout') ? $this->redirectAfterLogout
+            : config('backpack.base.route_prefix', 'admin');
     }
 
     // -------------------------------------------------------
@@ -61,5 +80,20 @@ class LoginController extends Controller
         $this->data['title'] = trans('backpack::base.login'); // set the page title
 
         return view('backpack::auth.login', $this->data);
+    }
+
+    /**
+     * Log the user out and redirect him to specific location
+     *
+     * @param \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function logout(Request $request)
+    {
+        // Do the default logout procedure
+        $this->defaultLogout($request);
+
+        // And redirect to custom location
+        return redirect($this->redirectAfterLogout);
     }
 }

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -26,21 +26,21 @@ class LoginController extends Controller
 
     
     /**
-     * If not logged in redirect here
+     * If not logged in redirect here.
      * 
      * @var string
      */
     protected $loginPath = 'admin/login';
     
     /**
-     * Redirect here after successful login
+     * Redirect here after successful login.
      * 
      * @var string
      */
     protected $redirectTo = 'admin/dashboard';
 
     /**
-     * Redirect here after logout
+     * Redirect here after logout.
      * 
      * @var string
      */
@@ -57,10 +57,10 @@ class LoginController extends Controller
 
         // Set up redirect paths if not specified
         $this->loginPath = property_exists($this, 'loginPath') ? $this->loginPath 
-            : config('backpack.base.route_prefix', 'admin') . '/login';
+            : config('backpack.base.route_prefix', 'admin').'/login';
 
         $this->redirectTo = property_exists($this, 'redirectTo') ? $this->redirectTo
-            : config('backpack.base.route_prefix', 'admin') . '/dashboard';
+            : config('backpack.base.route_prefix', 'admin').'/dashboard';
 
         $this->redirectAfterLogout = property_exists($this, 'redirectAfterLogout') ? $this->redirectAfterLogout
             : config('backpack.base.route_prefix', 'admin');
@@ -83,7 +83,7 @@ class LoginController extends Controller
     }
 
     /**
-     * Log the user out and redirect him to specific location
+     * Log the user out and redirect him to specific location.
      *
      * @param \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response


### PR DESCRIPTION
Well, this started as simple attempt to fix the logout procedure (Laravel redirects to '/' by default after logout), but once I was in I did the whole package.

- Reformated the docblocks a little bit
- Fixed the paths handling (whatever you had specified in the attributes was overwritten in the constructor, I've added some checks)
- Logout uses the default Laravel logout method, but redirects to location specified in LoginController
