### PR TITLE
Enable deep link to tab

### DIFF
--- a/src/resources/views/layout.blade.php
+++ b/src/resources/views/layout.blade.php
@@ -130,6 +130,12 @@
             $(this).parents('li').addClass('active');
           }
         });
+        {{-- Enable deep link to tab --}}
+        var activeTab = $('[href="' + location.hash.replace("#", "#tab_") + '"]');
+        activeTab && activeTab.tab('show');
+        $('.nav-tabs a').on('shown.bs.tab', function (e) {
+            location.hash = e.target.hash.replace("#tab_", "#");
+        });
     </script>
 
     @include('backpack::inc.alerts')


### PR DESCRIPTION
This is a non breaking change that:

- Combined with CRUD tabs, or standalone, allow you to click on a Tab and have URL filled with current tab, for easy copy&paste
- Allows to deep link any tab in a tabbed interface/form/whatever
- Prevents page "jumps" by aliasing the real tab names 

![image](https://cloud.githubusercontent.com/assets/389801/24969151/04166aa4-1fb0-11e7-9480-10780adc7e0a.png)
