### PR TITLE
Add option to switch authentication guards

### DIFF
--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Backpack\Base;
 
 use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Route;
 
@@ -27,6 +28,8 @@ class BaseServiceProvider extends ServiceProvider
         $this->loadViewsFrom(resource_path('views/vendor/backpack/base'), 'backpack');
         // - then the stock views that come with the package, in case a published view might be missing
         $this->loadViewsFrom(realpath(__DIR__.'/resources/views'), 'backpack');
+
+        View::composer('backpack::*', \Backpack\Base\app\Http\ViewComposers\AuthComposer::class);
 
         $this->loadTranslationsFrom(realpath(__DIR__.'/resources/lang'), 'backpack');
 

--- a/src/app/Http/Controllers/AdminController.php
+++ b/src/app/Http/Controllers/AdminController.php
@@ -11,7 +11,10 @@ class AdminController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('admin');
+        $guard = config('backpack.base.guard')
+            ?: config('auth.defaults.guard');
+
+        $this->middleware("admin:$guard");
     }
 
     /**

--- a/src/app/Http/Controllers/AdminController.php
+++ b/src/app/Http/Controllers/AdminController.php
@@ -11,10 +11,7 @@ class AdminController extends Controller
      */
     public function __construct()
     {
-        $guard = config('backpack.base.guard')
-            ?: config('auth.defaults.guard');
-
-        $this->middleware("admin:$guard");
+        $this->middleware('admin');
     }
 
     /**

--- a/src/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/src/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -4,6 +4,7 @@ namespace Backpack\Base\app\Http\Controllers\Auth;
 
 use Backpack\Base\app\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;
+use Illuminate\Support\Facades\Password;
 
 class ForgotPasswordController extends Controller
 {
@@ -29,7 +30,10 @@ class ForgotPasswordController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest');
+        $guard = config('backpack.base.guard')
+            ?: config('auth.defaults.guard');
+
+        $this->middleware("guest:$guard");
     }
 
     // -------------------------------------------------------
@@ -46,5 +50,13 @@ class ForgotPasswordController extends Controller
         $this->data['title'] = trans('backpack::base.reset_password'); // set the page title
 
         return view('backpack::auth.passwords.email', $this->data);
+    }
+
+    public function broker()
+    {
+        $passwords = config('backpack.base.passwords')
+            ?: config('auth.defaults.passwords');
+
+        return Password::broker($passwords);
     }
 }

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -2,10 +2,10 @@
 
 namespace Backpack\Base\app\Http\Controllers\Auth;
 
+use Auth;
 use Backpack\Base\app\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
-use Auth;
 
 class LoginController extends Controller
 {

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -5,6 +5,7 @@ namespace Backpack\Base\app\Http\Controllers\Auth;
 use Backpack\Base\app\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\Request;
+use Auth;
 
 class LoginController extends Controller
 {
@@ -31,7 +32,10 @@ class LoginController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest', ['except' => 'logout']);
+        $guard = config('backpack.base.guard')
+            ?: config('auth.defaults.guard');
+
+        $this->middleware("guest:$guard", ['except' => 'logout']);
 
         // ----------------------------------
         // Use the admin prefix in all routes
@@ -80,5 +84,13 @@ class LoginController extends Controller
 
         // And redirect to custom location
         return redirect($this->redirectAfterLogout);
+    }
+
+    protected function guard()
+    {
+        $guard = config('backpack.base.guard')
+            ?: config('auth.defaults.guard');
+
+        return Auth::guard($guard);
     }
 }

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -2,11 +2,11 @@
 
 namespace Backpack\Base\app\Http\Controllers\Auth;
 
+use Auth;
 use Backpack\Base\app\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Http\Request;
 use Validator;
-use Auth;
 
 class RegisterController extends Controller
 {

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -6,6 +6,7 @@ use Backpack\Base\app\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Http\Request;
 use Validator;
+use Auth;
 
 class RegisterController extends Controller
 {
@@ -30,7 +31,10 @@ class RegisterController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest');
+        $guard = config('backpack.base.guard')
+            ?: config('auth.defaults.guard');
+
+        $this->middleware("guest:$guard");
 
         // Where to redirect users after login / registration.
         $this->redirectTo = property_exists($this, 'redirectTo') ? $this->redirectTo
@@ -112,5 +116,13 @@ class RegisterController extends Controller
         $this->guard()->login($this->create($request->all()));
 
         return redirect($this->redirectPath());
+    }
+
+    protected function guard()
+    {
+        $guard = config('backpack.base.guard')
+            ?: config('auth.defaults.guard');
+
+        return Auth::guard($guard);
     }
 }

--- a/src/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -5,6 +5,8 @@ namespace Backpack\Base\app\Http\Controllers\Auth;
 use Backpack\Base\app\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\ResetsPasswords;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+use Auth;
 
 class ResetPasswordController extends Controller
 {
@@ -30,7 +32,10 @@ class ResetPasswordController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest');
+        $guard = config('backpack.base.guard')
+            ?: config('auth.defaults.guard');
+
+        $this->middleware("guest:$guard");
 
         // where to redirect after password was reset
         $this->redirectTo = property_exists($this, 'redirectTo') ? $this->redirectTo : config('backpack.base.route_prefix', 'admin').'/dashboard';
@@ -57,5 +62,21 @@ class ResetPasswordController extends Controller
         return view('backpack::auth.passwords.reset', $this->data)->with(
             ['token' => $token, 'email' => $request->email]
         );
+    }
+
+    public function broker()
+    {
+        $passwords = config('backpack.base.passwords')
+            ?: config('auth.defaults.passwords');
+
+        return Password::broker($passwords);
+    }
+
+    protected function guard()
+    {
+        $guard = config('backpack.base.guard')
+            ?: config('auth.defaults.guard');
+
+        return Auth::guard($guard);
     }
 }

--- a/src/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -2,11 +2,11 @@
 
 namespace Backpack\Base\app\Http\Controllers\Auth;
 
+use Auth;
 use Backpack\Base\app\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\ResetsPasswords;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
-use Auth;
 
 class ResetPasswordController extends Controller
 {

--- a/src/app/Http/Middleware/Admin.php
+++ b/src/app/Http/Middleware/Admin.php
@@ -12,12 +12,14 @@ class Admin
      *
      * @param \Illuminate\Http\Request $request
      * @param \Closure                 $next
-     * @param string|null              $guard
      *
      * @return mixed
      */
-    public function handle($request, Closure $next, $guard = null)
+    public function handle($request, Closure $next)
     {
+        $guard = config('backpack.base.guard')
+            ?: config('auth.defaults.guard');
+
         if (Auth::guard($guard)->guest()) {
             if ($request->ajax() || $request->wantsJson()) {
                 return response(trans('backpack::base.unauthorized'), 401);

--- a/src/app/Http/ViewComposers/AuthComposer.php
+++ b/src/app/Http/ViewComposers/AuthComposer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Backpack\Base\app\Http\ViewComposers;
+
+use Illuminate\View\View;
+use Illuminate\Support\Facades\Auth;
+
+class AuthComposer
+{
+    public function compose(View $view)
+    {
+        $guard = config('backpack.base.guard')
+            ?: config('auth.defaults.guard');
+
+        $view->with([
+            'backpackAuth' => Auth::guard($guard),
+        ]);
+    }
+}

--- a/src/app/Http/ViewComposers/AuthComposer.php
+++ b/src/app/Http/ViewComposers/AuthComposer.php
@@ -2,8 +2,8 @@
 
 namespace Backpack\Base\app\Http\ViewComposers;
 
-use Illuminate\View\View;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
 
 class AuthComposer
 {

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -68,11 +68,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | User Model
+    | Authentication
     |--------------------------------------------------------------------------
     */
 
     // Fully qualified namespace of the User model
     'user_model_fqn' => '\App\User',
+
+    // The guard that protects the Backpack admin panel. The default guard will
+    // be used if this is null.
+    'guard' => null,
+
+    // The password reset configuration for Backpack. The default configuration
+    // will be used if this is null.
+    'passwords' => null,
 
 ];

--- a/src/resources/views/inc/menu.blade.php
+++ b/src/resources/views/inc/menu.blade.php
@@ -19,7 +19,7 @@
 
       <!-- <li><a href="{{ url('/') }}"><i class="fa fa-home"></i> <span>Home</span></a></li> -->
 
-        @if (Auth::guest())
+        @if ($backpackAuth->guest())
             <li><a href="{{ url(config('backpack.base.route_prefix', 'admin').'/login') }}">{{ trans('backpack::base.login') }}</a></li>
             @if (config('backpack.base.registration_open'))
             <li><a href="{{ url(config('backpack.base.route_prefix', 'admin').'/register') }}">{{ trans('backpack::base.register') }}</a></li>

--- a/src/resources/views/inc/sidebar.blade.php
+++ b/src/resources/views/inc/sidebar.blade.php
@@ -1,4 +1,4 @@
-@if (Auth::check())
+@if ($backpackAuth->check())
     <!-- Left side column. contains the sidebar -->
     <aside class="main-sidebar">
       <!-- sidebar: style can be found in sidebar.less -->
@@ -6,10 +6,10 @@
         <!-- Sidebar user panel -->
         <div class="user-panel">
           <div class="pull-left image">
-            <img src="https://placehold.it/160x160/00a65a/ffffff/&text={{ mb_substr(Auth::user()->name, 0, 1) }}" class="img-circle" alt="User Image">
+            <img src="https://placehold.it/160x160/00a65a/ffffff/&text={{ mb_substr($backpackAuth->user()->name, 0, 1) }}" class="img-circle" alt="User Image">
           </div>
           <div class="pull-left info">
-            <p>{{ Auth::user()->name }}</p>
+            <p>{{ $backpackAuth->user()->name }}</p>
             <a href="#"><i class="fa fa-circle text-success"></i> Online</a>
           </div>
         </div>


### PR DESCRIPTION
This fixes #122.

I basically made it possible to switch authentication guards for backpack. This makes it possible to use a different guard besides the default one (from `config/auth.php`).

For instance, you have a guard for the users on the public facing part of the website. And you have a different guard for the admins of the website. So a `user` guard and an `admin` guard. If the `user` guard is the default one, then it was impossible to use the `admin` guard with backpack. This pull request makes it possible to set a specific guard for backpack.

There was already a config option `user_model_fqn` in backpack, but this only changed the behaviour of the user registration. More info about that in issue #122.

~~This should be a non-breaking change because the `user_model_fqn` config option is still present and being used. We could remove it and fetch the used model from the guard configuration, but that would be a breaking change.~~

This is a breaking change because the views are different now, and they have to be republished. Since it is a breaking change, I will also look into removing the `user_model_fqn` option.

Actually, the views only need to be republished, if you use the new `guard` option. The old views just use the default guard. So I'm not sure if this is breaking or not...