### PR TITLE
Enabled custom routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,48 @@ $ php artisan migrate #generates users table (using Laravel's default migrations
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
 
+## Custom Routing
+
+By default, every component registers its routes automatically. 
+If you want to disable this, in config/backpack/base.php
+set to true: 
+
+```'skip_all_backpack_routes' => true,```
+
+Then add to app/Providers/RouteServiceProvider.php
+
+```
+public function map()
+{
+    ...
+    
+    $this->mapBackpackRoutes(); // <<--THIS LINE
+    
+}
+
+protected function mapBackpackRoutes() <<--THIS FUNCTION
+{
+   Route::middleware('web')
+        ->prefix(config('backpack.base.route_prefix', 'admin'))
+        ->namespace('Backpack\PermissionManager\app\Http\Controllers')
+        ->group(base_path('routes/backpack.php'));
+}
+```
+
+## Permissions
+
+When you have custom routing, you can easily restrict access with **PermissionManager** module
+
+Example: restrict access to manage users
+
+- Create a "manage-users" permission
+- Add roles or users to that permission
+- Add can:manage-users to the routes/backpack.php file like this
+
+```CRUD::resource('user', 'UserCrudController')->middleware('can:manage-users');```
+
+
+
 ## Todos
 
 // TODO - instruct developer on how to modify/extend the AuthController and PasswordController and/or provide example

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -36,7 +36,9 @@ class BaseServiceProvider extends ServiceProvider
         );
 
         $this->registerAdminMiddleware($this->app->router);
-        $this->setupRoutes($this->app->router);
+        if(!config('backpack.base.skip_all_backpack_routes',false)){
+            $this->setupRoutes($this->app->router);            
+        }
         $this->publishFiles();
     }
 
@@ -133,5 +135,8 @@ class BaseServiceProvider extends ServiceProvider
 
         // publish public AdminLTE assets
         $this->publishes([base_path('vendor/almasaeed2010/adminlte') => public_path('vendor/adminlte')], 'adminlte');
+
+        // publish routes file
+        $this->publishes([__DIR__.'/routes' => base_path('routes')]);
     }
 }

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -54,6 +54,8 @@ return [
     | Routing
     |--------------------------------------------------------------------------
     */
+    // Set to true to disable registering routes in ALL backpack packages
+    'skip_all_backpack_routes' => false,
 
     // The prefix used in all base routes (the 'admin' in admin/dashboard)
     'route_prefix' => 'admin',

--- a/src/routes/backpack.php
+++ b/src/routes/backpack.php
@@ -36,17 +36,6 @@ Route::group(['namespace' => 'Backpack\Base\app\Http\Controllers'], function () 
     Route::get('/', 'AdminController@redirect');
 });
 
-//crud routes
-Route::group(['namespace' => 'Barryvdh\Elfinder', 'middleware' => 'admin'], function () {
-    Route::get('elfinder', ['as' => 'elfinder.index', 'uses' => 'ElfinderController@showIndex']);
-    Route::any('connector', ['as' => 'elfinder.connector', 'uses' => 'ElfinderController@showConnector']);
-    Route::get('popup/{input_id}', ['as' => 'elfinder.popup', 'uses' => 'ElfinderController@showPopup']);
-    Route::get('filepicker/{input_id}', ['as' => 'elfinder.filepicker', 'uses' => 'ElfinderController@showFilePicker']);
-    Route::get('tinymce', ['as' => 'elfinder.tinymce', 'uses' => 'ElfinderController@showTinyMCE']);
-    Route::get('tinymce4', ['as' => 'elfinder.tinymce4', 'uses' => 'ElfinderController@showTinyMCE4']);
-    Route::get('ckeditor', ['as' => 'elfinder.ckeditor', 'uses' => 'ElfinderController@showCKeditor4']);
-});
-
 //backupmanager
 Route::group(['namespace' => 'Backpack\BackupManager\app\Http\Controllers', 'middleware' => 'admin'], function () {
     Route::get('backup', 'BackupController@index');

--- a/src/routes/backpack.php
+++ b/src/routes/backpack.php
@@ -1,6 +1,6 @@
 <?php
 
-/* To use this file: 
+/* To use this file:
 1) in config/backpack/base.php
 set to true
 'skip_all_backpack_routes' => true,
@@ -9,77 +9,89 @@ set to true
 
 public function map()
 {
-    $this->mapApiRoutes();
+$this->mapApiRoutes();
 
-    $this->mapWebRoutes();
-    
-    $this->mapBackpackRoutes(); // THIS FUNCTION
-    
+$this->mapWebRoutes();
+
+$this->mapBackpackRoutes(); // THIS FUNCTION
+
 }
 
 protected function mapBackpackRoutes()
 {
-   Route::middleware('web')
-        ->prefix(config('backpack.base.route_prefix', 'admin'))
-        ->namespace('Backpack\PermissionManager\app\Http\Controllers')
-        ->group(base_path('routes/backpack.php'));
+Route::middleware('web')
+->prefix(config('backpack.base.route_prefix', 'admin'))
+->namespace('Backpack\PermissionManager\app\Http\Controllers')
+->group(base_path('routes/backpack.php'));
 }
-*/
+ */
 
-//auth
-Route::auth();
-Route::get('logout', 'Auth\LoginController@logout');
+Route::group(['namespace' => 'Backpack\Base\app\Http\Controllers'], function () {
+    //auth
+    Route::auth();
+    Route::get('logout', 'Auth\LoginController@logout');
 
-//dashboard
-Route::get('dashboard', 'AdminController@dashboard');
-Route::get('/', 'AdminController@redirect');
-
-
-Route::group(['middleware' => 'auth'], function () {
-	
-	//backupmanager
-	Route::get('backup', 'BackupController@index');
-	Route::put('backup/create', 'BackupController@create');
-	Route::get('backup/download/{file_name?}', 'BackupController@download');
-	Route::delete('backup/delete/{file_name?}', 'BackupController@delete')->where('file_name', '(.*)');
-
-	//LangFileManager
-	Route::get('language/texts/{lang?}/{file?}', 'LanguageCrudController@showTexts');
-	Route::post('language/texts/{lang}/{file}', 'LanguageCrudController@updateTexts');
-	Route::resource('language', 'LanguageCrudController');
-	
-	//permissionmanager
-	CRUD::resource('permission', 'PermissionCrudController');
-	CRUD::resource('role', 'RoleCrudController');
-	CRUD::resource('user', 'UserCrudController');
-
-	//logmanager
-	Route::get('log', 'LogController@index');
-	Route::get('log/preview/{file_name}', 'LogController@preview');
-	Route::get('log/download/{file_name}', 'LogController@download');
-	Route::delete('log/delete/{file_name}', 'LogController@delete');
-
-	//menucrud
-	CRUD::resource('menu-item', 'MenuItemCrudController');
-
-	//newscrud
-	CRUD::resource('article', 'ArticleCrudController');
-	CRUD::resource('category', 'CategoryCrudController');
-	CRUD::resource('tag', 'TagCrudController');
-
-	//pagemanager
-	Route::get('page/create/{template}', 'PageCrudController@create');
-	Route::get('page/{id}/edit/{template}', 'PageCrudController@edit');
-	Route::get('page/reorder', 'PageCrudController@reorder');
-	Route::get('page/reorder/{lang}', 'PageCrudController@reorder');
-	Route::post('page/reorder', 'PageCrudController@saveReorder');
-	Route::post('page/reorder/{lang}', 'PageCrudController@saveReorder');
-	Route::get('page/{id}/details', 'PageCrudController@showDetailsRow');
-	Route::get('page/{id}/translate/{lang}', 'PageCrudController@translateItem');
-	Route::resource('page', 'PageCrudController');
-
-	// Settings
-	Route::resource('setting', 'SettingCrudController');
-
+    //dashboard
+    Route::get('dashboard', 'AdminController@dashboard');
+    Route::get('/', 'AdminController@redirect');
 });
 
+//backupmanager
+Route::group(['namespace' => 'Backpack\BackupManager\app\Http\Controllers', 'middleware' => 'auth'], function () {
+    Route::get('backup', 'BackupController@index');
+    Route::put('backup/create', 'BackupController@create');
+    Route::get('backup/download/{file_name?}', 'BackupController@download');
+    Route::delete('backup/delete/{file_name?}', 'BackupController@delete')->where('file_name', '(.*)');
+});
+
+//LangFileManager
+Route::group(['namespace' => 'Backpack\LangFileManager\app\Http\Controllers', 'middleware' => 'auth'], function () {
+    Route::get('language/texts/{lang?}/{file?}', 'LanguageCrudController@showTexts');
+    Route::post('language/texts/{lang}/{file}', 'LanguageCrudController@updateTexts');
+    Route::resource('language', 'LanguageCrudController');
+});
+
+//permissionmanager
+Route::group(['namespace' => 'Backpack\PermissionManager\app\Http\Controllers', 'middleware' => 'auth'], function () {
+    CRUD::resource('permission', 'PermissionCrudController');
+    CRUD::resource('role', 'RoleCrudController');
+    CRUD::resource('user', 'UserCrudController');
+});
+
+//logmanager
+Route::group(['namespace' => 'Backpack\LogManager\app\Http\Controllers', 'middleware' => 'auth'], function () {
+    Route::get('log', 'LogController@index');
+    Route::get('log/preview/{file_name}', 'LogController@preview');
+    Route::get('log/download/{file_name}', 'LogController@download');
+    Route::delete('log/delete/{file_name}', 'LogController@delete');
+});
+
+//menucrud
+Route::group(['namespace' => 'Backpack\MenuCRUD\app\Http\Controllers', 'middleware' => 'auth'], function () {
+    CRUD::resource('menu-item', 'MenuItemCrudController');
+});
+
+//newscrud
+Route::group(['namespace' => 'Backpack\NewsCRUD\app\Http\Controllers', 'middleware' => 'auth'], function () {
+    CRUD::resource('article', 'ArticleCrudController');
+    CRUD::resource('category', 'CategoryCrudController');
+    CRUD::resource('tag', 'TagCrudController');
+});
+
+//pagemanager
+Route::group(['namespace' => 'Backpack\PageManager\app\Http\Controllers\Admin', 'middleware' => 'auth'], function () {
+    Route::get('page/create/{template}', 'PageCrudController@create');
+    Route::get('page/{id}/edit/{template}', 'PageCrudController@edit');
+    Route::get('page/reorder', 'PageCrudController@reorder');
+    Route::get('page/reorder/{lang}', 'PageCrudController@reorder');
+    Route::post('page/reorder', 'PageCrudController@saveReorder');
+    Route::post('page/reorder/{lang}', 'PageCrudController@saveReorder');
+    Route::get('page/{id}/details', 'PageCrudController@showDetailsRow');
+    Route::get('page/{id}/translate/{lang}', 'PageCrudController@translateItem');
+    Route::resource('page', 'PageCrudController');
+});
+
+// Settings
+Route::group(['namespace' => 'Backpack\Settings\app\Http\Controllers'], function () {
+    Route::resource('setting', 'SettingCrudController');
+});

--- a/src/routes/backpack.php
+++ b/src/routes/backpack.php
@@ -1,0 +1,85 @@
+<?php
+
+/* To use this file: 
+1) in config/backpack/base.php
+set to true
+'skip_all_backpack_routes' => true,
+
+2) Add to app/Providers/RouteServiceProvider.php
+
+public function map()
+{
+    $this->mapApiRoutes();
+
+    $this->mapWebRoutes();
+    
+    $this->mapBackpackRoutes(); // THIS FUNCTION
+    
+}
+
+protected function mapBackpackRoutes()
+{
+   Route::middleware('web')
+        ->prefix(config('backpack.base.route_prefix', 'admin'))
+        ->namespace('Backpack\PermissionManager\app\Http\Controllers')
+        ->group(base_path('routes/backpack.php'));
+}
+*/
+
+//auth
+Route::auth();
+Route::get('logout', 'Auth\LoginController@logout');
+
+//dashboard
+Route::get('dashboard', 'AdminController@dashboard');
+Route::get('/', 'AdminController@redirect');
+
+
+Route::group(['middleware' => 'auth'], function () {
+	
+	//backupmanager
+	Route::get('backup', 'BackupController@index');
+	Route::put('backup/create', 'BackupController@create');
+	Route::get('backup/download/{file_name?}', 'BackupController@download');
+	Route::delete('backup/delete/{file_name?}', 'BackupController@delete')->where('file_name', '(.*)');
+
+	//LangFileManager
+	Route::get('language/texts/{lang?}/{file?}', 'LanguageCrudController@showTexts');
+	Route::post('language/texts/{lang}/{file}', 'LanguageCrudController@updateTexts');
+	Route::resource('language', 'LanguageCrudController');
+	
+	//permissionmanager
+	CRUD::resource('permission', 'PermissionCrudController');
+	CRUD::resource('role', 'RoleCrudController');
+	CRUD::resource('user', 'UserCrudController');
+
+	//logmanager
+	Route::get('log', 'LogController@index');
+	Route::get('log/preview/{file_name}', 'LogController@preview');
+	Route::get('log/download/{file_name}', 'LogController@download');
+	Route::delete('log/delete/{file_name}', 'LogController@delete');
+
+	//menucrud
+	CRUD::resource('menu-item', 'MenuItemCrudController');
+
+	//newscrud
+	CRUD::resource('article', 'ArticleCrudController');
+	CRUD::resource('category', 'CategoryCrudController');
+	CRUD::resource('tag', 'TagCrudController');
+
+	//pagemanager
+	Route::get('page/create/{template}', 'PageCrudController@create');
+	Route::get('page/{id}/edit/{template}', 'PageCrudController@edit');
+	Route::get('page/reorder', 'PageCrudController@reorder');
+	Route::get('page/reorder/{lang}', 'PageCrudController@reorder');
+	Route::post('page/reorder', 'PageCrudController@saveReorder');
+	Route::post('page/reorder/{lang}', 'PageCrudController@saveReorder');
+	Route::get('page/{id}/details', 'PageCrudController@showDetailsRow');
+	Route::get('page/{id}/translate/{lang}', 'PageCrudController@translateItem');
+	Route::resource('page', 'PageCrudController');
+
+	// Settings
+	Route::resource('setting', 'SettingCrudController');
+
+});
+

--- a/src/routes/backpack.php
+++ b/src/routes/backpack.php
@@ -36,8 +36,19 @@ Route::group(['namespace' => 'Backpack\Base\app\Http\Controllers'], function () 
     Route::get('/', 'AdminController@redirect');
 });
 
+//crud routes
+Route::group(['namespace' => 'Barryvdh\Elfinder', 'middleware' => 'admin'], function () {
+    Route::get('elfinder', ['as' => 'elfinder.index', 'uses' => 'ElfinderController@showIndex']);
+    Route::any('connector', ['as' => 'elfinder.connector', 'uses' => 'ElfinderController@showConnector']);
+    Route::get('popup/{input_id}', ['as' => 'elfinder.popup', 'uses' => 'ElfinderController@showPopup']);
+    Route::get('filepicker/{input_id}', ['as' => 'elfinder.filepicker', 'uses' => 'ElfinderController@showFilePicker']);
+    Route::get('tinymce', ['as' => 'elfinder.tinymce', 'uses' => 'ElfinderController@showTinyMCE']);
+    Route::get('tinymce4', ['as' => 'elfinder.tinymce4', 'uses' => 'ElfinderController@showTinyMCE4']);
+    Route::get('ckeditor', ['as' => 'elfinder.ckeditor', 'uses' => 'ElfinderController@showCKeditor4']);
+});
+
 //backupmanager
-Route::group(['namespace' => 'Backpack\BackupManager\app\Http\Controllers', 'middleware' => 'auth'], function () {
+Route::group(['namespace' => 'Backpack\BackupManager\app\Http\Controllers', 'middleware' => 'admin'], function () {
     Route::get('backup', 'BackupController@index');
     Route::put('backup/create', 'BackupController@create');
     Route::get('backup/download/{file_name?}', 'BackupController@download');
@@ -45,21 +56,21 @@ Route::group(['namespace' => 'Backpack\BackupManager\app\Http\Controllers', 'mid
 });
 
 //LangFileManager
-Route::group(['namespace' => 'Backpack\LangFileManager\app\Http\Controllers', 'middleware' => 'auth'], function () {
+Route::group(['namespace' => 'Backpack\LangFileManager\app\Http\Controllers', 'middleware' => 'admin'], function () {
     Route::get('language/texts/{lang?}/{file?}', 'LanguageCrudController@showTexts');
     Route::post('language/texts/{lang}/{file}', 'LanguageCrudController@updateTexts');
     Route::resource('language', 'LanguageCrudController');
 });
 
 //permissionmanager
-Route::group(['namespace' => 'Backpack\PermissionManager\app\Http\Controllers', 'middleware' => 'auth'], function () {
+Route::group(['namespace' => 'Backpack\PermissionManager\app\Http\Controllers', 'middleware' => 'admin'], function () {
     CRUD::resource('permission', 'PermissionCrudController');
     CRUD::resource('role', 'RoleCrudController');
     CRUD::resource('user', 'UserCrudController');
 });
 
 //logmanager
-Route::group(['namespace' => 'Backpack\LogManager\app\Http\Controllers', 'middleware' => 'auth'], function () {
+Route::group(['namespace' => 'Backpack\LogManager\app\Http\Controllers', 'middleware' => 'admin'], function () {
     Route::get('log', 'LogController@index');
     Route::get('log/preview/{file_name}', 'LogController@preview');
     Route::get('log/download/{file_name}', 'LogController@download');
@@ -67,19 +78,19 @@ Route::group(['namespace' => 'Backpack\LogManager\app\Http\Controllers', 'middle
 });
 
 //menucrud
-Route::group(['namespace' => 'Backpack\MenuCRUD\app\Http\Controllers', 'middleware' => 'auth'], function () {
+Route::group(['namespace' => 'Backpack\MenuCRUD\app\Http\Controllers', 'middleware' => 'admin'], function () {
     CRUD::resource('menu-item', 'MenuItemCrudController');
 });
 
 //newscrud
-Route::group(['namespace' => 'Backpack\NewsCRUD\app\Http\Controllers', 'middleware' => 'auth'], function () {
+Route::group(['namespace' => 'Backpack\NewsCRUD\app\Http\Controllers', 'middleware' => 'admin'], function () {
     CRUD::resource('article', 'ArticleCrudController');
     CRUD::resource('category', 'CategoryCrudController');
     CRUD::resource('tag', 'TagCrudController');
 });
 
 //pagemanager
-Route::group(['namespace' => 'Backpack\PageManager\app\Http\Controllers\Admin', 'middleware' => 'auth'], function () {
+Route::group(['namespace' => 'Backpack\PageManager\app\Http\Controllers\Admin', 'middleware' => 'admin'], function () {
     Route::get('page/create/{template}', 'PageCrudController@create');
     Route::get('page/{id}/edit/{template}', 'PageCrudController@edit');
     Route::get('page/reorder', 'PageCrudController@reorder');


### PR DESCRIPTION
Hi! @tabacitu 

Im enabling custom routing for all packages. 

I created a config var "skip_all_backpack_routes" that disables all routes from being registered across all packages. 

It's disabled by default, so you only use it when the project grows. 

Custom routing will be in this file:

https://github.com/eduardoarandah/Base/blob/master/src/routes/backpack.php

Added this to readme:

## Custom Routing

By default, every component registers its routes automatically. 
If you want to disable this, in config/backpack/base.php
set to true: 

```'skip_all_backpack_routes' => true,```

Then add to app/Providers/RouteServiceProvider.php

```
public function map()
{
    ...
    
    $this->mapBackpackRoutes(); // <<--THIS LINE
    
}

protected function mapBackpackRoutes() <<--THIS FUNCTION
{
   Route::middleware('web')
        ->prefix(config('backpack.base.route_prefix', 'admin'))
        ->namespace('Backpack\PermissionManager\app\Http\Controllers')
        ->group(base_path('routes/backpack.php'));
}
```

## Permissions

When you have custom routing, you can easily restrict access with **PermissionManager** module

Example: restrict access to manage users

- Create a "manage-users" permission
- Add roles or users to that permission
- Add can:manage-users to the routes/backpack.php file like this

```CRUD::resource('user', 'UserCrudController')->middleware('can:manage-users');```

