### PR TITLE
Backend login with permission

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -45,6 +45,9 @@ class LoginController extends Controller
             : config('backpack.base.route_prefix', 'admin').'/dashboard';
 
         // Redirect here after logout.
+        if (config('backpack.base.permission_protection')) {
+            $this->redirectAfterLogout = 'login';
+        }
         $this->redirectAfterLogout = property_exists($this, 'redirectAfterLogout') ? $this->redirectAfterLogout
             : config('backpack.base.route_prefix', 'admin');
         // ----------------------------------

--- a/src/app/Http/Middleware/Admin.php
+++ b/src/app/Http/Middleware/Admin.php
@@ -20,11 +20,24 @@ class Admin
     {
         if (Auth::guard($guard)->guest()) {
             if ($request->ajax() || $request->wantsJson()) {
-                return response(trans('backpack::base.unauthorized'), 401);
+                abort(403);
             } else {
-                return redirect()->guest(config('backpack.base.route_prefix', 'admin').'/login');
+                if (!config('backpack.base.permission_protection')) 
+                {
+                    return redirect()->guest(config('backpack.base.route_prefix', 'admin').'/login');
+                }
+                return redirect()->guest('/login');
             }
         }
+
+        else if (config('backpack.base.permission_protection')) 
+        {
+            if (! $request->user()->can(config('backpack.base.permission_name'))) {
+                abort(403);          
+            }
+        }
+
+            
 
         return $next($request);
     }

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -75,4 +75,12 @@ return [
     // Fully qualified namespace of the User model
     'user_model_fqn' => '\App\User',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Permission protection
+    |--------------------------------------------------------------------------
+    */
+    'permission_protection' => true,
+    'permission_name' => 'login'
+
 ];


### PR DESCRIPTION
This PR just adds a simple permission check to logging in the backend. It is meant for projects that want to keep the user function and the admin function separate, without having 2 different tables for each of these 2 groups.

It is completely optional to use and all changes are used if the 'permission_protection' option is set to 'true' in the backpack configuration.

P.S: I am not an experienced programmer.