### PR TITLE
Filter's class 'active' treatment

### DIFF
--- a/src/resources/views/layout.blade.php
+++ b/src/resources/views/layout.blade.php
@@ -158,7 +158,7 @@
         $curentPageLink.parents('li').addClass('active');
         {{-- Enable deep link to tab --}}
         var activeTab = $('[href="' + location.hash.replace("#", "#tab_") + '"]');
-        activeTab && activeTab.tab('show');
+        location.hash && activeTab && activeTab.tab('show');
         $('.nav-tabs a').on('shown.bs.tab', function (e) {
             location.hash = e.target.hash.replace("#tab_", "#");
         });


### PR DESCRIPTION
Filter does not set the class as active when new value was selected.
When url has no hashes the upper line `var activeTab = $('[href="' + location.hash.replace("#", "#tab_") + '"]');` choose excess links and toggle off all active classes.
Changing to` location.hash && activeTab && activeTab.tab('show');`  solved the issue.