### PR TITLE
Remove route names

### DIFF
--- a/src/routes/backpack/base.php
+++ b/src/routes/backpack/base.php
@@ -19,7 +19,28 @@ Route::group(
 function () {
     // if not otherwise configured, setup the auth routes
     if (config('backpack.base.setup_auth_routes')) {
-        Route::auth();
+        
+        //same routes as when calling Route::auth() but without route names
+        //why? 
+        //If you want front-end users, you can use Auth::routes(); without conflict in route names 
+        //check: vendor/laravel/framework/src/Illuminate/Routing/Router.php
+        //
+        // Authentication Routes...
+        Route::get('login', 'Auth\LoginController@showLoginForm');
+        Route::post('login', 'Auth\LoginController@login');
+        Route::post('logout', 'Auth\LoginController@logout');
+
+        // Registration Routes...
+        Route::get('register', 'Auth\RegisterController@showRegistrationForm');
+        Route::post('register', 'Auth\RegisterController@register');
+
+        // Password Reset Routes...
+        Route::get('password/reset', 'Auth\ForgotPasswordController@showLinkRequestForm');
+        Route::post('password/email', 'Auth\ForgotPasswordController@sendResetLinkEmail');
+        Route::get('password/reset/{token}', 'Auth\ResetPasswordController@showResetForm');
+        Route::post('password/reset', 'Auth\ResetPasswordController@reset');
+        //end Route::auth();
+        
         Route::get('logout', 'Auth\LoginController@logout');
     }
 


### PR DESCRIPTION
when we want front-end users, adding Auth::routes(); to routes/web is impossible, because of route names overwritten

Look:
http://imgur.com/a/z5e9J

This change removes the conflict