### PR TITLE
Fixed small typo (on -> or)

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -81,7 +81,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | If you, your employer or your client make money by using Backpack, you need
-    | to purchase a license code. A license code will be provided after purchse,
+    | to purchase a license code. A license code will be provided after purchase,
     | which you can put here or in your ENV file.
     |
     | More info and payment form on:

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -82,7 +82,7 @@ return [
     |
     | If you, your employer or your client make money by using Backpack, you need
     | to purchase a license code. A license code will be provided after purchse,
-    | which you can put here on in your ENV file.
+    | which you can put here or in your ENV file.
     |
     | More info and payment form on:
     | https://www.backpackforlaravel.com


### PR DESCRIPTION
In the default configuration (src/config/backpack/base.php) there is a small typo:

`on` instead of `or`

---

Have a nice day,
Jordan 