### PR TITLE
Fix Gravatar use with a custom authentication guard

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -29,7 +29,7 @@ if (!function_exists('backpack_avatar')) {
     {
         switch (config('backpack.base.avatar_type')) {
             case 'gravatar':
-                return Gravatar::fallback('https://placehold.it/160x160/00a65a/ffffff/&text='.Auth::user()->name[0])->get($user->email);
+                return Gravatar::fallback('https://placehold.it/160x160/00a65a/ffffff/&text='.$user->name[0])->get($user->email);
                 break;
 
             case 'placehold':


### PR DESCRIPTION
When using Gravatar with a custom authentication guard, the application crashes as the user object is not obtained properly.