### PR TITLE
Define 'admin' as a Middleware Group

### DIFF
--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -101,9 +101,9 @@ class BaseServiceProvider extends ServiceProvider
 
     public function registerAdminMiddleware(Router $router)
     {
-        // in Laravel 5.4
-        if (method_exists($router, 'aliasMiddleware')) {
-            Route::aliasMiddleware('admin', \Backpack\Base\app\Http\Middleware\Admin::class);
+        // in Laravel 5.4 and above
+        if (method_exists($router, 'pushMiddlewareToGroup')) {
+            Route::pushMiddlewareToGroup('admin', \Backpack\Base\app\Http\Middleware\Admin::class);
         }
         // in Laravel 5.3 and below
         else {


### PR DESCRIPTION
Hello,

I think using a middleware group (instead of an alias) is a better practice here. Why? Because it allows developers to add other middlewares in the group (programmatically or using the `app/Http/Kernel.php` file.

According to me, there is no breaking changes. 
I did some tests under Laravel 5.4 and Laravel 5.5.