### PR TITLE
Command-line installer

### DIFF
--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -9,7 +9,7 @@ use Route;
 class BaseServiceProvider extends ServiceProvider
 {
     protected $commands = [
-        'Backpack\Base\app\Console\Commands\Install',
+        Backpack\Base\app\Console\Commands\Install::class,
     ];
 
     /**

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -8,6 +8,10 @@ use Route;
 
 class BaseServiceProvider extends ServiceProvider
 {
+    protected $commands = [
+        'Backpack\Base\app\Console\Commands\Install',
+    ];
+
     /**
      * Indicates if loading of the provider is deferred.
      *
@@ -97,6 +101,9 @@ class BaseServiceProvider extends ServiceProvider
                 $this->app->register('Backpack\Generators\GeneratorsServiceProvider');
             }
         }
+
+        // register the artisan commands
+        $this->commands($this->commands);
     }
 
     public function registerAdminMiddleware(Router $router)

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -53,12 +53,14 @@ class Install extends Command
     /**
      * Run a SSH command.
      *
-     * @param  string  $command      The SSH command that needs to be run
-     * @param  boolean $beforeNotice Information for the user before the command is run
-     * @param  boolean $afterNotice  Information for the user after the command is run
-     * @return mixed                 Command-line output
+     * @param string $command      The SSH command that needs to be run
+     * @param bool   $beforeNotice Information for the user before the command is run
+     * @param bool   $afterNotice  Information for the user after the command is run
+     *
+     * @return mixed Command-line output
      */
-    public function executeProcess($command, $beforeNotice = false, $afterNotice = false) {
+    public function executeProcess($command, $beforeNotice = false, $afterNotice = false)
+    {
         if ($beforeNotice) {
             $this->info('### '.$beforeNotice);
         } else {

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Backpack\Base\app\Console\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class Install extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:base:install';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Require dev packages and publish files for Backpack\Base to work';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->info("Backpack\Base installation started. Please wait...");
+
+        $this->executeProcess("composer require backpack/generators --dev");
+        $this->executeProcess("composer require laracasts/generators:dev-master --dev");
+        $this->executeProcess("php artisan vendor:publish --provider='Backpack\Base\BaseServiceProvider'", "publishing configs, langs, views and AdminLTE files");
+        $this->executeProcess("php artisan vendor:publish --provider='Prologue\Alerts\AlertsServiceProvider'", "publishing config for notifications - prologue/alerts");
+        $this->executeProcess("php artisan migrate", "generating users table (using Laravel's default migrations)");
+
+        $this->info("Backpack\Base installation finished.");
+    }
+
+    public function executeProcess($command, $beforeNotice = false, $afterNotice = false) {
+        if ($beforeNotice) {
+            $this->info("### ".$beforeNotice);
+        } else {
+            $this->info("### running: ".$command);
+        }
+
+
+        $process = new Process($command);
+        $process->run();
+
+        // executes after the command finishes
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+
+        echo $process->getOutput();
+
+        if ($afterNotice) {
+            $this->info("### ".$afterNotice);
+        }
+    }
+}

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -50,6 +50,14 @@ class Install extends Command
         $this->info("### Backpack\Base installation finished.");
     }
 
+    /**
+     * Run a SSH command.
+     *
+     * @param  string  $command      The SSH command that needs to be run
+     * @param  boolean $beforeNotice Information for the user before the command is run
+     * @param  boolean $afterNotice  Information for the user after the command is run
+     * @return mixed                 Command-line output
+     */
     public function executeProcess($command, $beforeNotice = false, $afterNotice = false) {
         if ($beforeNotice) {
             $this->info("### ".$beforeNotice);

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -39,7 +39,7 @@ class Install extends Command
      */
     public function handle()
     {
-        $this->info("Backpack\Base installation started. Please wait...");
+        $this->info("### Backpack\Base installation started. Please wait...");
 
         $this->executeProcess("composer require backpack/generators --dev");
         $this->executeProcess("composer require laracasts/generators:dev-master --dev");
@@ -47,26 +47,29 @@ class Install extends Command
         $this->executeProcess("php artisan vendor:publish --provider='Prologue\Alerts\AlertsServiceProvider'", "publishing config for notifications - prologue/alerts");
         $this->executeProcess("php artisan migrate", "generating users table (using Laravel's default migrations)");
 
-        $this->info("Backpack\Base installation finished.");
+        $this->info("### Backpack\Base installation finished.");
     }
 
     public function executeProcess($command, $beforeNotice = false, $afterNotice = false) {
         if ($beforeNotice) {
             $this->info("### ".$beforeNotice);
         } else {
-            $this->info("### running: ".$command);
+            $this->info("### Running: ".$command);
         }
 
-
         $process = new Process($command);
-        $process->run();
+        $process->run(function ($type, $buffer) {
+            if (Process::ERR === $type) {
+                echo '... > '.$buffer;
+            } else {
+                echo 'OUT > '.$buffer;
+            }
+        });
 
         // executes after the command finishes
         if (!$process->isSuccessful()) {
             throw new ProcessFailedException($process);
         }
-
-        echo $process->getOutput();
 
         if ($afterNotice) {
             $this->info("### ".$afterNotice);


### PR DESCRIPTION
FINALLY! Right? :-)

Instead of asking the developer to run a bunch of commands, ```php artisan backpack:base:install``` will run them all. 

This drastically reduces the number of steps needed to install Backpack\Base. Take a look at the output here: https://cl.ly/1b1v413s1q1T If we do this AND decide to use our own AdminUser class for authentication (that extends User), this will make installing Backpack\Base a two-step process:
```php
composer require backpack/base
php artisan backpack:base:install
```

That's the end goal here - for every Backpack package to be installed as easy as that, with that naming convention (```backpack:crud:install```, ```backpack:pagemanager:install```, etc). And every compatible Backpack package to follow this same standard.

@OwenMelbz , @lloy0076 what do you guys think so far? Command naming ok?

Thanks, cheers!