### PR TITLE
fix class not found error

### DIFF
--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -9,7 +9,7 @@ use Route;
 class BaseServiceProvider extends ServiceProvider
 {
     protected $commands = [
-        Backpack\Base\app\Console\Commands\Install::class,
+        \Backpack\Base\app\Console\Commands\Install::class,
     ];
 
     /**


### PR DESCRIPTION
After upgrade backpack/crud to 3.3.* and backpack/base to 0.8.* the following error is shown.

[ReflectionException]                                                          
Class Backpack\Base\Backpack\Base\app\Console\Commands\Install does not exist