### PR TITLE
fix missing \

### DIFF
--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -9,7 +9,7 @@ use Route;
 class BaseServiceProvider extends ServiceProvider
 {
     protected $commands = [
-        Backpack\Base\app\Console\Commands\Install::class,
+        \Backpack\Base\app\Console\Commands\Install::class,
     ];
 
     /**


### PR DESCRIPTION
Added backslash in the command. Otherwise the `php artisan package:discover` returns with this error-
```
[ReflectionException]
  Class Backpack\Base\Backpack\Base\app\Console\Commands\Install does not exist
```