### PR TITLE
Fix cannot run php artisan package:discover

### DIFF
--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -9,7 +9,7 @@ use Route;
 class BaseServiceProvider extends ServiceProvider
 {
     protected $commands = [
-        Backpack\Base\app\Console\Commands\Install::class,
+        app\Console\Commands\Install::class,
     ];
 
     /**


### PR DESCRIPTION
There is error when run command "php artisan package:discover", because of Class Backpack\Base\Backpack\Base\app\Console\Commands\Install does not exist