### PR TITLE
Using guard() method to access the current guard in MyAccountController

### DIFF
--- a/src/app/Http/Controllers/Auth/MyAccountController.php
+++ b/src/app/Http/Controllers/Auth/MyAccountController.php
@@ -24,7 +24,7 @@ class MyAccountController extends Controller
     public function getAccountInfoForm()
     {
         $this->data['title'] = trans('backpack::base.my_account');
-        $this->data['user'] = Auth::user();
+        $this->data['user'] = $this->guard()->user();
 
         return view('backpack::auth.account.update_info', $this->data);
     }
@@ -34,7 +34,7 @@ class MyAccountController extends Controller
      */
     public function postAccountInfoForm(AccountInfoRequest $request)
     {
-        $result = Auth::user()->update($request->except(['_token']));
+        $result = $this->guard()->user()->update($request->except(['_token']));
 
         if ($result) {
             Alert::success(trans('backpack::base.account_updated'))->flash();
@@ -51,7 +51,7 @@ class MyAccountController extends Controller
     public function getChangePasswordForm()
     {
         $this->data['title'] = trans('backpack::base.my_account');
-        $this->data['user'] = Auth::user();
+        $this->data['user'] = $this->guard()->user();
 
         return view('backpack::auth.account.change_password', $this->data);
     }
@@ -61,7 +61,7 @@ class MyAccountController extends Controller
      */
     public function postChangePasswordForm(ChangePasswordRequest $request)
     {
-        $user = Auth::user();
+        $user = $this->guard()->user();
         $user->password = Hash::make($request->new_password);
 
         if ($user->save()) {
@@ -71,5 +71,15 @@ class MyAccountController extends Controller
         }
 
         return redirect()->back();
+    }
+
+    /**
+     * Get the guard to be used for account manipulation.
+     *
+     * @return \Illuminate\Contracts\Auth\StatefulGuard
+     */
+    protected function guard()
+    {
+        return Auth::guard();
     }
 }


### PR DESCRIPTION
So we are able to override the Guard to a custom one in one place instead of all over the Controller.

It's (afaik) the standard way to do this - the default Login/Register Traits are doing it like this, so should we :)

Should also fix #210