### PR TITLE
[Feature][1.0][WIP] Support AdminLTE original Auth pages style with some changes to blades structs

### DIFF
--- a/src/public/overlays/backpack.bold.css
+++ b/src/public/overlays/backpack.bold.css
@@ -48,3 +48,14 @@ body {
 .pace .pace-activity {
 	display: none;
 }
+
+.login-page, .register-page {
+	background: #ecf0f5;
+}
+
+.login-footer {
+	position: absolute;
+	text-align: center;
+	bottom: 5px;
+	width: 100%;
+}

--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -1,66 +1,90 @@
 @extends('backpack::layout')
 
-@section('content')
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2">
-            <div class="box box-default">
-                <div class="box-header with-border">
-                    <div class="box-title">{{ trans('backpack::base.login') }}</div>
+@section('after_styles')
+    <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/plugins/iCheck/square/blue.css">
+    <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/dist/css/auth.css">
+@endsection
+
+@section('body_attributes')
+    login-page
+@endsection
+
+@section('login-box')
+
+    <div class="login-box">
+        <div class="login-logo">
+            <a href="{{ url('') }}">{!! config('backpack.base.logo_lg') !!}</a>
+        </div>
+        <!-- /.login-logo -->
+        <div class="login-box-body">
+            <p class="login-box-msg">{{ trans('backpack::base.login') }}</p>
+
+            <form role="form" method="POST" action="{{ route('backpack.auth.login') }}">
+                {!! csrf_field() !!}
+
+                <div class="form-group has-feedback {{ $errors->has('email') ? 'has-error' : '' }}">
+                    <input type="email" name="email" class="form-control" value="{{ old('email') }}"
+                           placeholder="{{ trans('backpack::base.email_address') }}">
+                    <span class="glyphicon glyphicon-envelope form-control-feedback"></span>
+                    @if ($errors->has('email'))
+                        <span class="help-block">
+                            <strong>{{ $errors->first('email') }}</strong>
+                        </span>
+                    @endif
                 </div>
-                <div class="box-body">
-                    <form class="form-horizontal" role="form" method="POST" action="{{ route('backpack.auth.login') }}">
-                        {!! csrf_field() !!}
 
-                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label">{{ trans('backpack::base.email_address') }}</label>
-
-                            <div class="col-md-6">
-                                <input type="email" class="form-control" name="email" value="{{ old('email') }}">
-
-                                @if ($errors->has('email'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label">{{ trans('backpack::base.password') }}</label>
-
-                            <div class="col-md-6">
-                                <input type="password" class="form-control" name="password">
-
-                                @if ($errors->has('password'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group">
-                            <div class="col-md-6 col-md-offset-4">
-                                <div class="checkbox">
-                                    <label>
-                                        <input type="checkbox" name="remember"> {{ trans('backpack::base.remember_me') }}
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="form-group">
-                            <div class="col-md-6 col-md-offset-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ trans('backpack::base.login') }}
-                                </button>
-
-                                <a class="btn btn-link" href="{{ route('backpack.auth.password.reset') }}">{{ trans('backpack::base.forgot_your_password') }}</a>
-                            </div>
-                        </div>
-                    </form>
+                <div class="form-group has-feedback {{ $errors->has('password') ? 'has-error' : '' }}">
+                    <input type="password" name="password" class="form-control"
+                           placeholder="{{ trans('backpack::base.password') }}">
+                    <span class="glyphicon glyphicon-lock form-control-feedback"></span>
+                    @if ($errors->has('password'))
+                        <span class="help-block">
+                            <strong>{{ $errors->first('password') }}</strong>
+                        </span>
+                    @endif
                 </div>
+
+                <div class="row">
+                    <div class="col-xs-8">
+                        <div class="checkbox icheck">
+                            <label>
+                                <input type="checkbox" name="remember"> {{ trans('backpack::base.remember_me') }}
+                            </label>
+                        </div>
+                    </div>
+                    <!-- /.col -->
+                    <div class="col-xs-4">
+                        <button type="submit"
+                                class="btn btn-primary btn-block btn-flat">{{ trans('backpack::base.login') }}</button>
+                    </div>
+                    <!-- /.col -->
+                </div>
+            </form>
+
+            <div class="auth-links">
+                <a href="{{ route('backpack.auth.password.reset') }}"
+                   class="text-center"
+                >{{ trans('backpack::base.forgot_your_password') }}</a>
+                <br>
+                @if (config('backpack.base.registration_open'))
+                    <a href="{{ route('backpack.auth.register') }}"
+                       class="text-center"
+                    >{{ trans('backpack::base.register') }}</a>
+                @endif
             </div>
         </div>
     </div>
+@endsection
+
+@section('after_scripts')
+    <script src="{{ asset('vendor/adminlte') }}/plugins/iCheck/icheck.min.js"></script>
+    <script>
+        $(function () {
+            $('input').iCheck({
+                checkboxClass: 'icheckbox_square-blue',
+                radioClass: 'iradio_square-blue',
+                increaseArea: '20%' // optional
+            });
+        });
+    </script>
 @endsection

--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -1,4 +1,4 @@
-@extends('backpack::layout')
+@extends('backpack::layout_guest')
 
 @section('after_styles')
     <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/plugins/iCheck/square/blue.css">

--- a/src/resources/views/auth/passwords/email.blade.php
+++ b/src/resources/views/auth/passwords/email.blade.php
@@ -1,4 +1,4 @@
-@extends('backpack::layout')
+@extends('backpack::layout_guest')
 
 @section('after_styles')
     <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/dist/css/auth.css">

--- a/src/resources/views/auth/passwords/email.blade.php
+++ b/src/resources/views/auth/passwords/email.blade.php
@@ -1,47 +1,47 @@
 @extends('backpack::layout')
 
-<!-- Main Content -->
-@section('content')
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2">
-            <div class="box box-default">
-                <div class="box-header with-border">
-                    <div class="box-title">{{ trans('backpack::base.reset_password') }}</div>
+@section('after_styles')
+    <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/dist/css/auth.css">
+@endsection
+
+@section('body_attributes')
+    login-page
+@endsection
+
+@section('login-box')
+    <div class="login-box">
+        <div class="login-logo">
+            <a href="{{ url('') }}">{!! config('backpack.base.logo_lg') !!}</a>
+        </div>
+        <!-- /.login-logo -->
+        <div class="login-box-body">
+            <p class="login-box-msg">{{ trans('backpack::base.reset_password') }}</p>
+
+            @if (session('status'))
+                <div class="alert alert-success">
+                    {{ session('status') }}
                 </div>
-                <div class="box-body">
-                    @if (session('status'))
-                        <div class="alert alert-success">
-                            {{ session('status') }}
-                        </div>
+            @endif
+
+            <form role="form" method="POST" action="{{ route('backpack.auth.password.email') }}">
+                {!! csrf_field() !!}
+
+                <div class="form-group has-feedback {{ $errors->has('email') ? 'has-error' : '' }}">
+                    <input type="email" name="email" class="form-control" value="{{ old('email') }}"
+                           placeholder="{{ trans('backpack::base.email_address') }}">
+                    <span class="glyphicon glyphicon-envelope form-control-feedback"></span>
+                    @if ($errors->has('email'))
+                        <span class="help-block">
+                            <strong>{{ $errors->first('email') }}</strong>
+                        </span>
                     @endif
-
-                    <form class="form-horizontal" role="form" method="POST" action="{{ route('backpack.auth.password.email') }}">
-                        {!! csrf_field() !!}
-
-                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label">{{ trans('backpack::base.email_address') }}</label>
-
-                            <div class="col-md-6">
-                                <input type="email" class="form-control" name="email" value="{{ old('email') }}">
-
-                                @if ($errors->has('email'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group">
-                            <div class="col-md-6 col-md-offset-4">
-                                <button type="submit" class="btn btn-primary">
-                                    <i class="fa fa-btn fa-envelope"></i> {{ trans('backpack::base.send_reset_link') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
                 </div>
-            </div>
+
+                <button type="submit"
+                        class="btn btn-primary btn-block btn-flat"
+                ><i class="fa fa-btn fa-envelope"></i> {{ trans('backpack::base.send_reset_link') }}</button>
+
+            </form>
         </div>
     </div>
 @endsection

--- a/src/resources/views/auth/passwords/reset.blade.php
+++ b/src/resources/views/auth/passwords/reset.blade.php
@@ -1,4 +1,4 @@
-@extends('backpack::layout')
+@extends('backpack::layout_guest')
 
 
 @section('after_styles')

--- a/src/resources/views/auth/passwords/reset.blade.php
+++ b/src/resources/views/auth/passwords/reset.blade.php
@@ -1,70 +1,66 @@
 @extends('backpack::layout')
 
-@section('content')
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2">
-            <div class="box box-default">
-                <div class="box-header with-border">
-                    <div class="box-title">{{ trans('backpack::base.reset_password') }}</div>
+
+@section('after_styles')
+    <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/dist/css/auth.css">
+@endsection
+
+@section('body_attributes')
+    login-page
+@endsection
+
+@section('login-box')
+    <div class="login-box">
+        <div class="login-logo">
+            <a href="{{ url('') }}">{!! config('backpack.base.logo_lg') !!}</a>
+        </div>
+        <!-- /.login-logo -->
+        <div class="login-box-body">
+            <p class="login-box-msg">{{ trans('backpack::base.reset_password') }}</p>
+
+            <form role="form" method="POST" action="{{ route('backpack.auth.password.reset') }}">
+                {!! csrf_field() !!}
+
+                <input type="hidden" name="token" value="{{ $token }}">
+
+                <div class="form-group has-feedback {{ $errors->has('email') ? 'has-error' : '' }}">
+                    <input type="email" name="email" class="form-control" value="{{ old('email') }}"
+                           placeholder="{{ trans('backpack::base.email_address') }}">
+                    <span class="glyphicon glyphicon-envelope form-control-feedback"></span>
+                    @if ($errors->has('email'))
+                        <span class="help-block">
+                            <strong>{{ $errors->first('email') }}</strong>
+                        </span>
+                    @endif
                 </div>
 
-                <div class="box-body">
-                    <form class="form-horizontal" role="form" method="POST" action="{{ route('backpack.auth.password.reset') }}">
-                        {!! csrf_field() !!}
-
-                        <input type="hidden" name="token" value="{{ $token }}">
-
-                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label">{{ trans('backpack::base.email_address') }}</label>
-
-                            <div class="col-md-6">
-                                <input type="email" class="form-control" name="email" value="{{ $email or old('email') }}">
-
-                                @if ($errors->has('email'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label">{{ trans('backpack::base.password') }}</label>
-
-                            <div class="col-md-6">
-                                <input type="password" class="form-control" name="password">
-
-                                @if ($errors->has('password'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group{{ $errors->has('password_confirmation') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label">{{ trans('backpack::base.confirm_password') }}</label>
-                            <div class="col-md-6">
-                                <input type="password" class="form-control" name="password_confirmation">
-
-                                @if ($errors->has('password_confirmation'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password_confirmation') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group">
-                            <div class="col-md-6 col-md-offset-4">
-                                <button type="submit" class="btn btn-primary">
-                                    <i class="fa fa-btn fa-refresh"></i> {{ trans('backpack::base.reset_password') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
+                <div class="form-group has-feedback {{ $errors->has('password') ? 'has-error' : '' }}">
+                    <input type="password" name="password" class="form-control"
+                           placeholder="{{ trans('backpack::base.password') }}">
+                    <span class="glyphicon glyphicon-lock form-control-feedback"></span>
+                    @if ($errors->has('password'))
+                        <span class="help-block">
+                            <strong>{{ $errors->first('password') }}</strong>
+                        </span>
+                    @endif
                 </div>
-            </div>
+
+                <div class="form-group has-feedback {{ $errors->has('password_confirmation') ? 'has-error' : '' }}">
+                    <input type="password" name="password_confirmation" class="form-control"
+                           placeholder="{{ trans('backpack::base.confirm_password') }}">
+                    <span class="glyphicon glyphicon-log-in form-control-feedback"></span>
+                    @if ($errors->has('password_confirmation'))
+                        <span class="help-block">
+                            <strong>{{ $errors->first('password_confirmation') }}</strong>
+                        </span>
+                    @endif
+                </div>
+
+                <button type="submit"
+                        class="btn btn-primary btn-block btn-flat"
+                >{{ trans('backpack::base.reset_password') }}</button>
+
+            </form>
         </div>
     </div>
 @endsection

--- a/src/resources/views/auth/register.blade.php
+++ b/src/resources/views/auth/register.blade.php
@@ -1,4 +1,4 @@
-@extends('backpack::layout')
+@extends('backpack::layout_guest')
 
 @section('after_styles')
     <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/dist/css/auth.css">

--- a/src/resources/views/auth/register.blade.php
+++ b/src/resources/views/auth/register.blade.php
@@ -1,82 +1,78 @@
 @extends('backpack::layout')
 
-@section('content')
-    <div class="row">
-        <div class="col-md-8 col-md-offset-2">
-            <div class="box box-default">
-                <div class="box-header with-border">
-                    <div class="box-title">{{ trans('backpack::base.register') }}</div>
+@section('after_styles')
+    <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/dist/css/auth.css">
+@endsection
+
+@section('body_attributes')
+    register-page
+@endsection
+
+@section('login-box')
+    <div class="register-box">
+        <div class="register-logo">
+            <a href="{{ url('') }}">{!! config('backpack.base.logo_lg') !!}</a>
+        </div>
+
+        <div class="register-box-body">
+            <p class="login-box-msg">{{ trans('backpack::base.register') }}</p>
+            <form role="form" method="POST" action="{{ route('backpack.auth.register') }}" method="post">
+                {!! csrf_field() !!}
+
+                <div class="form-group has-feedback {{ $errors->has('name') ? 'has-error' : '' }}">
+                    <input type="text" name="name" class="form-control" value="{{ old('name') }}"
+                           placeholder="{{ trans('backpack::base.name') }}">
+                    <span class="glyphicon glyphicon-user form-control-feedback"></span>
+                    @if ($errors->has('name'))
+                        <span class="help-block">
+                            <strong>{{ $errors->first('name') }}</strong>
+                        </span>
+                    @endif
                 </div>
-                <div class="box-body">
-                    <form class="form-horizontal" role="form" method="POST" action="{{ route('backpack.auth.register') }}">
-                        {!! csrf_field() !!}
 
-                        <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label">{{ trans('backpack::base.name') }}</label>
-
-                            <div class="col-md-6">
-                                <input type="text" class="form-control" name="name" value="{{ old('name') }}">
-
-                                @if ($errors->has('name'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('name') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label">{{ trans('backpack::base.email_address') }}</label>
-
-                            <div class="col-md-6">
-                                <input type="email" class="form-control" name="email" value="{{ old('email') }}">
-
-                                @if ($errors->has('email'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('email') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label">{{ trans('backpack::base.password') }}</label>
-
-                            <div class="col-md-6">
-                                <input type="password" class="form-control" name="password">
-
-                                @if ($errors->has('password'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group{{ $errors->has('password_confirmation') ? ' has-error' : '' }}">
-                            <label class="col-md-4 control-label">{{ trans('backpack::base.confirm_password') }}</label>
-
-                            <div class="col-md-6">
-                                <input type="password" class="form-control" name="password_confirmation">
-
-                                @if ($errors->has('password_confirmation'))
-                                    <span class="help-block">
-                                        <strong>{{ $errors->first('password_confirmation') }}</strong>
-                                    </span>
-                                @endif
-                            </div>
-                        </div>
-
-                        <div class="form-group">
-                            <div class="col-md-6 col-md-offset-4">
-                                <button type="submit" class="btn btn-primary">
-                                    <i class="fa fa-btn fa-user"></i> {{ trans('backpack::base.register') }}
-                                </button>
-                            </div>
-                        </div>
-                    </form>
+                <div class="form-group has-feedback {{ $errors->has('email') ? 'has-error' : '' }}">
+                    <input type="email" name="email" class="form-control" value="{{ old('email') }}"
+                           placeholder="{{ trans('backpack::base.email_address') }}">
+                    <span class="glyphicon glyphicon-envelope form-control-feedback"></span>
+                    @if ($errors->has('email'))
+                        <span class="help-block">
+                            <strong>{{ $errors->first('email') }}</strong>
+                        </span>
+                    @endif
                 </div>
+
+                <div class="form-group has-feedback {{ $errors->has('password') ? 'has-error' : '' }}">
+                    <input type="password" name="password" class="form-control"
+                           placeholder="{{ trans('backpack::base.password') }}">
+                    <span class="glyphicon glyphicon-lock form-control-feedback"></span>
+                    @if ($errors->has('password'))
+                        <span class="help-block">
+                            <strong>{{ $errors->first('password') }}</strong>
+                        </span>
+                    @endif
+                </div>
+
+                <div class="form-group has-feedback {{ $errors->has('password_confirmation') ? 'has-error' : '' }}">
+                    <input type="password" name="password_confirmation" class="form-control"
+                           placeholder="{{ trans('backpack::base.confirm_password') }}">
+                    <span class="glyphicon glyphicon-log-in form-control-feedback"></span>
+                    @if ($errors->has('password_confirmation'))
+                        <span class="help-block">
+                            <strong>{{ $errors->first('password_confirmation') }}</strong>
+                        </span>
+                    @endif
+                </div>
+
+                <button type="submit"
+                        class="btn btn-primary btn-block btn-flat"
+                >{{ trans('backpack::base.register') }}</button>
+            </form>
+
+            <div class="auth-links">
+                <a href="{{ route('backpack.auth.login') }}"
+                   class="text-center">{{ trans('backpack::base.login') }}</a>
             </div>
         </div>
     </div>
 @endsection
+

--- a/src/resources/views/inc/footer.blade.php
+++ b/src/resources/views/inc/footer.blade.php
@@ -1,0 +1,8 @@
+<footer class="main-footer">
+    @if (config('backpack.base.show_powered_by'))
+        <div class="pull-right hidden-xs">
+            {{ trans('backpack::base.powered_by') }} <a target="_blank" href="http://backpackforlaravel.com?ref=panel_footer_link">Backpack for Laravel</a>
+        </div>
+    @endif
+    {{ trans('backpack::base.handcrafted_by') }} <a target="_blank" href="{{ config('backpack.base.developer_link') }}">{{ config('backpack.base.developer_name') }}</a>.
+</footer>

--- a/src/resources/views/inc/footer_guest.blade.php
+++ b/src/resources/views/inc/footer_guest.blade.php
@@ -1,0 +1,5 @@
+@if (config('backpack.base.show_powered_by'))
+        <div class="login-footer">
+                {{ trans('backpack::base.powered_by') }} <a target="_blank" href="http://backpackforlaravel.com?ref=panel_footer_link">Backpack for Laravel</a>
+        </div>
+@endif

--- a/src/resources/views/inc/head.blade.php
+++ b/src/resources/views/inc/head.blade.php
@@ -1,0 +1,38 @@
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+{{-- Encrypted CSRF token for Laravel, in order for Ajax requests to work --}}
+<meta name="csrf-token" content="{{ csrf_token() }}" />
+
+<title>
+    {{ isset($title) ? $title.' :: '.config('backpack.base.project_name').' Admin' : config('backpack.base.project_name').' Admin' }}
+</title>
+
+@yield('before_styles')
+
+<meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+<!-- Bootstrap 3.3.5 -->
+<link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/bootstrap/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
+
+<link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/dist/css/AdminLTE.min.css">
+<!-- AdminLTE Skins. Choose a skin from the css/skins folder instead of downloading all of them to reduce the load. -->
+<link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/dist/css/skins/_all-skins.min.css">
+
+<link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/plugins/pace/pace.min.css">
+<link rel="stylesheet" href="{{ asset('vendor/backpack/pnotify/pnotify.custom.min.css') }}">
+
+<!-- BackPack Base CSS -->
+<link rel="stylesheet" href="{{ asset('vendor/backpack/backpack.base.css') }}?v=2">
+<link rel="stylesheet" href="{{ asset('vendor/backpack/overlays/backpack.bold.css') }}">
+
+@yield('after_styles')
+
+<!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+<!--[if lt IE 9]>
+<script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+<![endif]-->

--- a/src/resources/views/inc/main_header.blade.php
+++ b/src/resources/views/inc/main_header.blade.php
@@ -1,0 +1,21 @@
+<header class="main-header">
+    <!-- Logo -->
+    <a href="{{ url('') }}" class="logo">
+        <!-- mini logo for sidebar mini 50x50 pixels -->
+        <span class="logo-mini">{!! config('backpack.base.logo_mini') !!}</span>
+        <!-- logo for regular state and mobile devices -->
+        <span class="logo-lg">{!! config('backpack.base.logo_lg') !!}</span>
+    </a>
+    <!-- Header Navbar: style can be found in header.less -->
+    <nav class="navbar navbar-static-top" role="navigation">
+        <!-- Sidebar toggle button-->
+        <a href="#" class="sidebar-toggle" data-toggle="offcanvas" role="button">
+            <span class="sr-only">{{ trans('backpack::base.toggle_navigation') }}</span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+        </a>
+
+        @include('backpack::inc.menu')
+    </nav>
+</header>

--- a/src/resources/views/inc/menu.blade.php
+++ b/src/resources/views/inc/menu.blade.php
@@ -19,13 +19,8 @@
 
       <!-- <li><a href="{{ url('/') }}"><i class="fa fa-home"></i> <span>Home</span></a></li> -->
       @if (config('backpack.base.setup_auth_routes'))
-        @if (Auth::guest())
-            <li><a href="{{ route('backpack.auth.login') }}">{{ trans('backpack::base.login') }}</a></li>
-            @if (config('backpack.base.registration_open'))
-            <li><a href="{{ route('backpack.auth.register') }}">{{ trans('backpack::base.register') }}</a></li>
-            @endif
-        @else
-            <li><a href="{{ route('backpack.auth.logout') }}"><i class="fa fa-btn fa-sign-out"></i> {{ trans('backpack::base.logout') }}</a></li>
+        @if (Auth::check())
+                <li><a href="{{ route('backpack.auth.logout') }}"><i class="fa fa-btn fa-sign-out"></i> {{ trans('backpack::base.logout') }}</a></li>
         @endif
        @endif
        <!-- ========== End of top menu right items ========== -->

--- a/src/resources/views/inc/scripts.blade.php
+++ b/src/resources/views/inc/scripts.blade.php
@@ -1,0 +1,57 @@
+<!-- jQuery 2.2.3 -->
+<script src="https://code.jquery.com/jquery-2.2.3.min.js"></script>
+<script>window.jQuery || document.write('<script src="{{ asset('vendor/adminlte') }}/plugins/jQuery/jQuery-2.2.3.min.js"><\/script>')</script>
+<!-- Bootstrap 3.3.5 -->
+<script src="{{ asset('vendor/adminlte') }}/bootstrap/js/bootstrap.min.js"></script>
+<script src="{{ asset('vendor/adminlte') }}/plugins/pace/pace.min.js"></script>
+<script src="{{ asset('vendor/adminlte') }}/plugins/slimScroll/jquery.slimscroll.min.js"></script>
+<script src="{{ asset('vendor/adminlte') }}/plugins/fastclick/fastclick.js"></script>
+<script src="{{ asset('vendor/adminlte') }}/dist/js/app.min.js"></script>
+
+<!-- page script -->
+<script type="text/javascript">
+
+    // Ajax calls should always have the CSRF token attached to them, otherwise they won't work
+    $.ajaxSetup({
+        headers: {
+            'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+        }
+    });
+
+    @if (\Illuminate\Support\Facades\View::hasSection('content'))
+    /* Store sidebar state */
+    $('.sidebar-toggle').click(function(event) {
+        event.preventDefault();
+        if (Boolean(sessionStorage.getItem('sidebar-toggle-collapsed'))) {
+            sessionStorage.setItem('sidebar-toggle-collapsed', '');
+        } else {
+            sessionStorage.setItem('sidebar-toggle-collapsed', '1');
+        }
+    });
+    // To make Pace works on Ajax calls
+    $(document).ajaxStart(function() { Pace.restart(); });
+
+    // Set active state on menu element
+    var current_url = "{{ Request::fullUrl() }}";
+    var full_url = current_url+location.search;
+    var $navLinks = $("ul.sidebar-menu li a");
+    // First look for an exact match including the search string
+    var $curentPageLink = $navLinks.filter(
+        function() { return $(this).attr('href') === full_url; }
+    );
+    // If not found, look for the link that starts with the url
+    if(!$curentPageLink.length > 0){
+        $curentPageLink = $navLinks.filter(
+            function() { return $(this).attr('href').startsWith(current_url) || current_url.startsWith($(this).attr('href')); }
+        );
+    }
+
+    $curentPageLink.parents('li').addClass('active');
+            {{-- Enable deep link to tab --}}
+    var activeTab = $('[href="' + location.hash.replace("#", "#tab_") + '"]');
+    location.hash && activeTab && activeTab.tab('show');
+    $('.nav-tabs a').on('shown.bs.tab', function (e) {
+        location.hash = e.target.hash.replace("#tab_", "#");
+    });
+    @endif
+</script>

--- a/src/resources/views/layout.blade.php
+++ b/src/resources/views/layout.blade.php
@@ -1,175 +1,72 @@
 <!DOCTYPE html>
 <html lang="{{ app()->getLocale() }}">
 <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-
-    {{-- Encrypted CSRF token for Laravel, in order for Ajax requests to work --}}
-    <meta name="csrf-token" content="{{ csrf_token() }}" />
-
-    <title>
-      {{ isset($title) ? $title.' :: '.config('backpack.base.project_name').' Admin' : config('backpack.base.project_name').' Admin' }}
-    </title>
-
-    @yield('before_styles')
-
-    <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
-    <!-- Bootstrap 3.3.5 -->
-    <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/bootstrap/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
-
-    <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/dist/css/AdminLTE.min.css">
-    <!-- AdminLTE Skins. Choose a skin from the css/skins folder instead of downloading all of them to reduce the load. -->
-    <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/dist/css/skins/_all-skins.min.css">
-
-    <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/plugins/pace/pace.min.css">
-    <link rel="stylesheet" href="{{ asset('vendor/backpack/pnotify/pnotify.custom.min.css') }}">
-
-    <!-- BackPack Base CSS -->
-    <link rel="stylesheet" href="{{ asset('vendor/backpack/backpack.base.css') }}?v=2">
-    <link rel="stylesheet" href="{{ asset('vendor/backpack/overlays/backpack.bold.css') }}">
-
-    @yield('after_styles')
-
-    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
-    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
-    <!--[if lt IE 9]>
-    <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
-    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
+    @include('backpack::inc.head')
 </head>
-<body class="hold-transition {{ config('backpack.base.skin') }} sidebar-mini">
-	<script type="text/javascript">
-		/* Recover sidebar state */
-		(function () {
-			if (Boolean(sessionStorage.getItem('sidebar-toggle-collapsed'))) {
-				var body = document.getElementsByTagName('body')[0];
-				body.className = body.className + ' sidebar-collapse';
-			}
-		})();
-	</script>
+<body class="hold-transition @if (\Illuminate\Support\Facades\View::hasSection('login-box')) @yield('body_attributes') @else {{ config('backpack.base.skin') }} sidebar-mini @endif">
+
+@if (\Illuminate\Support\Facades\View::hasSection('login-box'))
+    @yield('login-box')
+@else
+    <script type="text/javascript">
+        /* Recover sidebar state */
+        (function () {
+            if (Boolean(sessionStorage.getItem('sidebar-toggle-collapsed'))) {
+                var body = document.getElementsByTagName('body')[0];
+                body.className = body.className + ' sidebar-collapse';
+            }
+        })();
+    </script>
     <!-- Site wrapper -->
     <div class="wrapper">
 
-      <header class="main-header">
-        <!-- Logo -->
-        <a href="{{ url('') }}" class="logo">
-          <!-- mini logo for sidebar mini 50x50 pixels -->
-          <span class="logo-mini">{!! config('backpack.base.logo_mini') !!}</span>
-          <!-- logo for regular state and mobile devices -->
-          <span class="logo-lg">{!! config('backpack.base.logo_lg') !!}</span>
-        </a>
-        <!-- Header Navbar: style can be found in header.less -->
-        <nav class="navbar navbar-static-top" role="navigation">
-          <!-- Sidebar toggle button-->
-          <a href="#" class="sidebar-toggle" data-toggle="offcanvas" role="button">
-            <span class="sr-only">{{ trans('backpack::base.toggle_navigation') }}</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-          </a>
+    @include('backpack::inc.main_header')
 
-          @include('backpack::inc.menu')
-        </nav>
-      </header>
+    <!-- =============================================== -->
 
-      <!-- =============================================== -->
+    @include('backpack::inc.sidebar')
 
-      @include('backpack::inc.sidebar')
+    <!-- =============================================== -->
 
-      <!-- =============================================== -->
-
-      <!-- Content Wrapper. Contains page content -->
-      <div class="content-wrapper">
-        <!-- Content Header (Page header) -->
-         @yield('header')
+        <!-- Content Wrapper. Contains page content -->
+        <div class="content-wrapper">
+            <!-- Content Header (Page header) -->
+        @yield('header')
 
         <!-- Main content -->
-        <section class="content">
+            <section class="content">
 
-          @yield('content')
+                @yield('content')
 
-        </section>
-        <!-- /.content -->
-      </div>
-      <!-- /.content-wrapper -->
+            </section>
+            <!-- /.content -->
+        </div>
+        <!-- /.content-wrapper -->
 
-      <footer class="main-footer">
-        @if (config('backpack.base.show_powered_by'))
-            <div class="pull-right hidden-xs">
-              {{ trans('backpack::base.powered_by') }} <a target="_blank" href="http://backpackforlaravel.com?ref=panel_footer_link">Backpack for Laravel</a>
-            </div>
-        @endif
-        {{ trans('backpack::base.handcrafted_by') }} <a target="_blank" href="{{ config('backpack.base.developer_link') }}">{{ config('backpack.base.developer_name') }}</a>.
-      </footer>
+        <footer class="main-footer">
+            @if (config('backpack.base.show_powered_by'))
+                <div class="pull-right hidden-xs">
+                    {{ trans('backpack::base.powered_by') }} <a target="_blank" href="http://backpackforlaravel.com?ref=panel_footer_link">Backpack for Laravel</a>
+                </div>
+            @endif
+            {{ trans('backpack::base.handcrafted_by') }} <a target="_blank" href="{{ config('backpack.base.developer_link') }}">{{ config('backpack.base.developer_name') }}</a>.
+        </footer>
     </div>
     <!-- ./wrapper -->
 
 
-    @yield('before_scripts')
+@endif
 
-    <!-- jQuery 2.2.3 -->
-    <script src="https://code.jquery.com/jquery-2.2.3.min.js"></script>
-    <script>window.jQuery || document.write('<script src="{{ asset('vendor/adminlte') }}/plugins/jQuery/jQuery-2.2.3.min.js"><\/script>')</script>
-    <!-- Bootstrap 3.3.5 -->
-    <script src="{{ asset('vendor/adminlte') }}/bootstrap/js/bootstrap.min.js"></script>
-    <script src="{{ asset('vendor/adminlte') }}/plugins/pace/pace.min.js"></script>
-    <script src="{{ asset('vendor/adminlte') }}/plugins/slimScroll/jquery.slimscroll.min.js"></script>
-    <script src="{{ asset('vendor/adminlte') }}/plugins/fastclick/fastclick.js"></script>
-    <script src="{{ asset('vendor/adminlte') }}/dist/js/app.min.js"></script>
+@yield('before_scripts')
 
-    <!-- page script -->
-    <script type="text/javascript">
-        /* Store sidebar state */
-        $('.sidebar-toggle').click(function(event) {
-          event.preventDefault();
-          if (Boolean(sessionStorage.getItem('sidebar-toggle-collapsed'))) {
-            sessionStorage.setItem('sidebar-toggle-collapsed', '');
-          } else {
-            sessionStorage.setItem('sidebar-toggle-collapsed', '1');
-          }
-        });
-        // To make Pace works on Ajax calls
-        $(document).ajaxStart(function() { Pace.restart(); });
+@include('backpack::inc.scripts')
 
-        // Ajax calls should always have the CSRF token attached to them, otherwise they won't work
-        $.ajaxSetup({
-                headers: {
-                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
-                }
-            });
-            
-        // Set active state on menu element
-        var current_url = "{{ Request::fullUrl() }}";
-        var full_url = current_url+location.search;
-        var $navLinks = $("ul.sidebar-menu li a");
-        // First look for an exact match including the search string
-        var $curentPageLink = $navLinks.filter(
-            function() { return $(this).attr('href') === full_url; }
-        );
-        // If not found, look for the link that starts with the url
-        if(!$curentPageLink.length > 0){
-            $curentPageLink = $navLinks.filter(
-                function() { return $(this).attr('href').startsWith(current_url) || current_url.startsWith($(this).attr('href')); }
-            );
-        }
-        
-        $curentPageLink.parents('li').addClass('active');
-        {{-- Enable deep link to tab --}}
-        var activeTab = $('[href="' + location.hash.replace("#", "#tab_") + '"]');
-        location.hash && activeTab && activeTab.tab('show');
-        $('.nav-tabs a').on('shown.bs.tab', function (e) {
-            location.hash = e.target.hash.replace("#tab_", "#");
-        });
-    </script>
+@include('backpack::inc.alerts')
 
-    @include('backpack::inc.alerts')
+@yield('after_scripts')
 
-    @yield('after_scripts')
+<!-- JavaScripts -->
+{{-- <script src="{{ mix('js/app.js') }}"></script> --}}
 
-    <!-- JavaScripts -->
-    {{-- <script src="{{ mix('js/app.js') }}"></script> --}}
 </body>
 </html>

--- a/src/resources/views/layout.blade.php
+++ b/src/resources/views/layout.blade.php
@@ -3,59 +3,46 @@
 <head>
     @include('backpack::inc.head')
 </head>
-<body class="hold-transition @if (\Illuminate\Support\Facades\View::hasSection('login-box')) @yield('body_attributes') @else {{ config('backpack.base.skin') }} sidebar-mini @endif">
+<body class="hold-transition {{ config('backpack.base.skin') }} sidebar-mini">
 
-@if (\Illuminate\Support\Facades\View::hasSection('login-box'))
-    @yield('login-box')
-@else
-    <script type="text/javascript">
-        /* Recover sidebar state */
-        (function () {
-            if (Boolean(sessionStorage.getItem('sidebar-toggle-collapsed'))) {
-                var body = document.getElementsByTagName('body')[0];
-                body.className = body.className + ' sidebar-collapse';
-            }
-        })();
-    </script>
-    <!-- Site wrapper -->
-    <div class="wrapper">
+<script type="text/javascript">
+    /* Recover sidebar state */
+    (function () {
+        if (Boolean(sessionStorage.getItem('sidebar-toggle-collapsed'))) {
+            var body = document.getElementsByTagName('body')[0];
+            body.className = body.className + ' sidebar-collapse';
+        }
+    })();
+</script>
+<!-- Site wrapper -->
+<div class="wrapper">
 
-    @include('backpack::inc.main_header')
+@include('backpack::inc.main_header')
 
-    <!-- =============================================== -->
+<!-- =============================================== -->
 
-    @include('backpack::inc.sidebar')
+@include('backpack::inc.sidebar')
 
-    <!-- =============================================== -->
+<!-- =============================================== -->
 
-        <!-- Content Wrapper. Contains page content -->
-        <div class="content-wrapper">
-            <!-- Content Header (Page header) -->
-        @yield('header')
+    <!-- Content Wrapper. Contains page content -->
+    <div class="content-wrapper">
+        <!-- Content Header (Page header) -->
+    @yield('header')
 
-        <!-- Main content -->
-            <section class="content">
+    <!-- Main content -->
+        <section class="content">
 
-                @yield('content')
+            @yield('content')
 
-            </section>
-            <!-- /.content -->
-        </div>
-        <!-- /.content-wrapper -->
-
-        <footer class="main-footer">
-            @if (config('backpack.base.show_powered_by'))
-                <div class="pull-right hidden-xs">
-                    {{ trans('backpack::base.powered_by') }} <a target="_blank" href="http://backpackforlaravel.com?ref=panel_footer_link">Backpack for Laravel</a>
-                </div>
-            @endif
-            {{ trans('backpack::base.handcrafted_by') }} <a target="_blank" href="{{ config('backpack.base.developer_link') }}">{{ config('backpack.base.developer_name') }}</a>.
-        </footer>
+        </section>
+        <!-- /.content -->
     </div>
-    <!-- ./wrapper -->
+    <!-- /.content-wrapper -->
 
-
-@endif
+    @include('backpack::inc.footer')
+</div>
+<!-- ./wrapper -->
 
 @yield('before_scripts')
 

--- a/src/resources/views/layout_guest.blade.php
+++ b/src/resources/views/layout_guest.blade.php
@@ -3,7 +3,7 @@
 <head>
     @include('backpack::inc.head')
 </head>
-<body class="hold-transition {{ config('backpack.base.skin') }} sidebar-mini">
+<body class="hold-transition @yield('body_attributes')">
 
 @yield('login-box')
 

--- a/src/resources/views/layout_guest.blade.php
+++ b/src/resources/views/layout_guest.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    @include('backpack::inc.head')
+</head>
+<body class="hold-transition {{ config('backpack.base.skin') }} sidebar-mini">
+
+@yield('login-box')
+
+@include('backpack::inc.footer_guest')
+
+@yield('before_scripts')
+
+@include('backpack::inc.scripts')
+
+@include('backpack::inc.alerts')
+
+@yield('after_scripts')
+
+<!-- JavaScripts -->
+{{-- <script src="{{ mix('js/app.js') }}"></script> --}}
+
+</body>
+</html>


### PR DESCRIPTION
separated head, main_header and scripts to new blades, added support for adminlte original login page style for auth blades

example of auth pages

Register Page

![capture d ecran 2018-01-15 a 03 14 53](https://user-images.githubusercontent.com/1247248/34924213-5555ca50-f9a2-11e7-8c89-bb5e6672bc13.png)

Login Page

![capture d ecran 2018-01-15 a 03 14 41](https://user-images.githubusercontent.com/1247248/34924215-558cfaa2-f9a2-11e7-93ce-fdf4c19b4f3b.png)

Email Page
![capture d ecran 2018-01-15 a 03 14 46](https://user-images.githubusercontent.com/1247248/34924214-55723884-f9a2-11e7-96de-92ee191107ad.png)
