### PR TITLE
Added Laravel 5.6 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Nothing
 
 
+## [0.8.8] - 2018-02-08
+
+## Added
+- Laravel 5.6 support;
+
+
 ## [0.8.7] - 2018-01-18
 
 ## Added

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Laravel BackPack's central package, which includes:
 
 ![Example generated CRUD interface](https://backpackforlaravel.com/uploads/screenshots/base_login.png)
 
-## Install on Laravel 5.5
+## Install on Laravel 5.5 or 5.6
 
 1) Run in your terminal:
 
@@ -47,7 +47,7 @@ php artisan backpack:base:install
 
 3) [optional] Change values in config/backpack/base.php to make the admin panel your own. Change menu color, project name, developer name etc.
 
-## Install on Laravel 5.4 / 5.3
+## Install on Laravel 5.4 or 5.3
 
 1) Run in your terminal:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Laravel BackPack's central package, which includes:
 
 ![Example generated CRUD interface](https://backpackforlaravel.com/uploads/screenshots/base_login.png)
 
-## Install on Laravel 5.5 or 5.6
+## Install on Laravel 5.6 or 5.5
 
 1) Run in your terminal:
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "almasaeed2010/AdminLTE" : "2.3.*",
-        "laravel/framework": "5.5.*,5.6.*",
+        "laravel/framework": "5.5.*|5.6.*",
         "prologue/alerts": "^0.4.1",
         "jenssegers/date": "^3.2",
         "creativeorange/gravatar": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "almasaeed2010/AdminLTE" : "2.3.*",
-        "laravel/framework": "5.5.*",
+        "laravel/framework": "5.5.*,5.6.*",
         "prologue/alerts": "^0.4.1",
         "jenssegers/date": "^3.2",
         "creativeorange/gravatar": "~1.0"


### PR DESCRIPTION
Backpack works like a charm on L5.6, [the only PR we need merged is this one](https://github.com/barryvdh/laravel-elfinder/pull/224). Once it is, we can merge this and officially support Laravel 5.6.