### PR TITLE
Auth\Login: allow username customization

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 class LoginController extends Controller
 {
     protected $data = []; // the information we send to the view
+    protected $user_auth_key = 'email';
 
     /*
     |--------------------------------------------------------------------------
@@ -33,6 +34,8 @@ class LoginController extends Controller
     {
         $this->middleware('guest', ['except' => 'logout']);
 
+        $this->user_auth_key = config('backpack.base.user_auth_key', 'email');
+
         // ----------------------------------
         // Use the admin prefix in all routes
 
@@ -48,6 +51,16 @@ class LoginController extends Controller
         $this->redirectAfterLogout = property_exists($this, 'redirectAfterLogout') ? $this->redirectAfterLogout
             : config('backpack.base.route_prefix', 'admin');
         // ----------------------------------
+    }
+
+    /**
+     * Return custom username for authentication.
+     *
+     * @return string
+     */
+    public function username()
+    {
+        return $this->user_auth_key;
     }
 
     // -------------------------------------------------------

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -81,6 +81,9 @@ return [
     // Fully qualified namespace of the User model
     'user_model_fqn' => '\App\User',
 
+    // Username key for authentication
+    'user_auth_key' => 'email',
+
     // What kind of avatar will you like to show to the user?
     // Default: gravatar (automatically use the gravatar for his email)
     // Other options:


### PR DESCRIPTION
If you change your User model to use another field that email to authenticate, you can't use BackPack.
(In my case, I use Adldap2 to login with AD username)
You need to update `login.blade.php` to allow `username` instead of `email` field.