### PR TITLE
[Feature][0.9][Merged] Alert messages can now have HTML content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Security
 - Nothing
 
+-------
+
+### Added
+- flexbox css helper class;
+- support for HTML messages inside Alert bubbles, when triggered from PHP;
+
 
 ## [0.8.9] - 2018-02-08
 

--- a/src/public/backpack.base.css
+++ b/src/public/backpack.base.css
@@ -841,6 +841,13 @@ body[class^='skin-purple'] .pagination>.active>span:hover {
     border-color: #f8d053;
   }
 
+  /*    FLEXBOX HELPERS */
+
+  .display-flex-wrap {
+    display: flex;
+    flex-wrap: wrap;
+  }
+
   /*    BORDER RADIUS HELPERS */
 
   .b-rad-sm {

--- a/src/resources/views/inc/alerts.blade.php
+++ b/src/resources/views/inc/alerts.blade.php
@@ -13,7 +13,7 @@
             $(function(){
               new PNotify({
                 // title: 'Regular Notice',
-                text: "{{ $message }}",
+                text: "{!! str_replace('"', "'", $message) !!}",
                 type: "{{ $type }}",
                 icon: false
               });


### PR DESCRIPTION
So that you can do things like:

```
<strong>Something happened</strong><br>
Details about that something, that nobody will probably ever read.
```

This is NOT a breaking change, it's backwards-compatible, but we should make sure we don't use this feature ourselves in the code, until it's adopted. For this reason, I think it should be launched with the 3.4 update.