### PR TITLE
[Feature][0.9][Merged] publish minimum amount of files; added sidebar_content file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - added publish lang command;
 - added command to publish only the minimum amount of files needed for Backpack to work;
 - ```sidebar_content.blade.php``` file, so that we can add sidebar items using a command
+- ```php artisan backpack:base:add-sidebar-content``` command;
 
 ### Fixed
 - the installation command now only published the minimum amount of files, by default;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - ```php artisan backpack:base:add-sidebar-content``` command;
 
 ### Fixed
-- the installation command now only published the minimum amount of files, by default;
+- the installation command now only publishes the minimum amount of files, by default;
 
 ## [0.8.9] - 2018-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 ### Security
 - Nothing
 
+------
+
+### Added
+- added publish lang command;
+- added command to publish only the minimum amount of files needed for Backpack to work;
+- ```sidebar_content.blade.php``` file, so that we can add sidebar items using a command
+
+### Fixed
+- the installation command now only published the minimum amount of files, by default;
 
 ## [0.8.9] - 2018-02-08
 

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -124,28 +124,41 @@ class BaseServiceProvider extends ServiceProvider
 
     public function publishFiles()
     {
-        // publish config file
-        $this->publishes([__DIR__.'/config' => config_path()], 'config');
+        $error_views = [__DIR__.'/resources/error_views' => resource_path('views/errors')];
+        $backpack_base_views = [__DIR__.'/resources/views' => resource_path('views/vendor/backpack/base')];
+        $backpack_public_assets = [__DIR__.'/public' => public_path('vendor/backpack')];
+        $backpack_lang_files = [__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')];
+        $backpack_config_files = [__DIR__.'/config' => config_path()];
 
-        // publish lang files
-        // $this->publishes([__DIR__.'/resources/lang' => resource_path('lang/vendor/backpack')], 'lang');
-
-        // publish views
-        $this->publishes([__DIR__.'/resources/views' => resource_path('views/vendor/backpack/base')], 'views');
-
-        // publish error views
-        $this->publishes([__DIR__.'/resources/error_views' => resource_path('views/errors')], 'errors');
-
-        // publish public Backpack assets
-        $this->publishes([__DIR__.'/public' => public_path('vendor/backpack')], 'public');
+        // sidebar_content view, which is the only view most people need to overwrite
+        $backpack_sidebar_contents_view = [__DIR__.'/resources/views/inc/sidebar_content.blade.php' => resource_path('views/vendor/backpack/base/inc/sidebar_content.blade.php')];
 
         // calculate the path from current directory to get the vendor path
         $vendorPath = dirname(__DIR__, 3);
+        $adminlte_assets = [$vendorPath.'/almasaeed2010/adminlte' => public_path('vendor/adminlte')];
+        $gravatar_assets = [$vendorPath.'/creativeorange/gravatar/config' => config_path()];
 
-        // publish public AdminLTE assets
-        $this->publishes([$vendorPath.'/almasaeed2010/adminlte' => public_path('vendor/adminlte')], 'adminlte');
+        // establish the minimum amount of files that need to be published, for Backpack to work; there are the files that will be published by the install command
+        $minimum = array_merge(
+            $error_views,
+            // $backpack_base_views,
+            $backpack_public_assets,
+            // $backpack_lang_files,
+            $backpack_config_files,
+            $backpack_sidebar_contents_view,
+            $adminlte_assets,
+            $gravatar_assets
+        );
 
-        // publish public Gravatar assets
-        $this->publishes([$vendorPath.'/creativeorange/gravatar/config' => config_path()], 'gravatar');
+        // register all possible publish commands and assign tags to each
+        $this->publishes($backpack_config_files, 'config');
+        $this->publishes($backpack_lang_files, 'lang');
+        $this->publishes($backpack_base_views, 'views');
+        $this->publishes($backpack_sidebar_contents_view, 'sidebar_content');
+        $this->publishes($error_views, 'errors');
+        $this->publishes($backpack_public_assets, 'public');
+        $this->publishes($adminlte_assets, 'adminlte');
+        $this->publishes($gravatar_assets, 'gravatar');
+        $this->publishes($minimum, 'minimum');
     }
 }

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -10,7 +10,7 @@ class BaseServiceProvider extends ServiceProvider
 {
     protected $commands = [
         \Backpack\Base\app\Console\Commands\Install::class,
-        \Backpack\Base\app\Console\Commands\AddSidebarItem::class,
+        \Backpack\Base\app\Console\Commands\AddSidebarContent::class,
     ];
 
     /**

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -10,6 +10,7 @@ class BaseServiceProvider extends ServiceProvider
 {
     protected $commands = [
         \Backpack\Base\app\Console\Commands\Install::class,
+        \Backpack\Base\app\Console\Commands\AddSidebarItem::class,
     ];
 
     /**
@@ -45,6 +46,12 @@ class BaseServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__.'/config/backpack/base.php', 'backpack.base'
         );
+
+        // add the root disk to filesystem configuration
+        app()->config['filesystems.disks.root'] = [
+            'driver' => 'local',
+            'root'   => base_path(),
+        ];
 
         $this->registerAdminMiddleware($this->app->router);
         $this->setupRoutes($this->app->router);

--- a/src/app/Console/Commands/AddSidebarContent.php
+++ b/src/app/Console/Commands/AddSidebarContent.php
@@ -5,14 +5,14 @@ namespace Backpack\Base\app\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
 
-class AddSidebarItem extends Command
+class AddSidebarContent extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'backpack:base:add-sidebar-item
+    protected $signature = 'backpack:base:add-sidebar-content
                                 {code : HTML/PHP code that shows the sidebar item. Use either single quotes or double quotes. Never both. }';
 
     /**
@@ -20,7 +20,7 @@ class AddSidebarItem extends Command
      *
      * @var string
      */
-    protected $description = 'Add an item to the Backpack sidebar';
+    protected $description = 'Add HTML/PHP code to the Backpack sidebar_content file';
 
     /**
      * Create a new command instance.
@@ -47,12 +47,12 @@ class AddSidebarItem extends Command
             $contents = Storage::disk('root')->get($path);
 
             if ($disk->put($path, $contents.PHP_EOL.$code)) {
-                $this->info("Successfully added sidebar item.");
+                $this->info("Successfully added code to sidebar_content file.");
             } else {
                 $this->error("Could not write to sidebar_content file.");
             }
         } else {
-            $this->error("The file sidebar_content.blade.php does not exist. Make sure Backpack\Base is properly installed.");
+            $this->error("The sidebar_content file does not exist. Make sure Backpack\Base is properly installed.");
         }
     }
 }

--- a/src/app/Console/Commands/AddSidebarItem.php
+++ b/src/app/Console/Commands/AddSidebarItem.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Backpack\Base\app\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class AddSidebarItem extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:base:add-sidebar-item
+                                {code : HTML/PHP code that shows the sidebar item. Use either single quotes or double quotes. Never both. }';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add an item to the Backpack sidebar';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $path = 'resources/views/vendor/backpack/base/inc/sidebar_content.blade.php';
+        $disk = Storage::disk('root');
+        $code = $this->argument('code');
+
+        if ($disk->exists($path)) {
+            $contents = Storage::disk('root')->get($path);
+
+            if ($disk->put($path, $contents.PHP_EOL.$code)) {
+                $this->info("Successfully added sidebar item.");
+            } else {
+                $this->error("Could not write to sidebar_content file.");
+            }
+        } else {
+            $this->error("The file sidebar_content.blade.php does not exist. Make sure Backpack\Base is properly installed.");
+        }
+    }
+}

--- a/src/app/Console/Commands/Install.php
+++ b/src/app/Console/Commands/Install.php
@@ -55,7 +55,7 @@ class Install extends Command
         $this->executeProcess('composer require laracasts/generators:dev-master --dev');
 
         $this->line(' Publishing configs, langs, views and AdminLTE files');
-        $this->executeProcess('php artisan vendor:publish --provider="Backpack\Base\BaseServiceProvider"');
+        $this->executeProcess('php artisan vendor:publish --provider="Backpack\Base\BaseServiceProvider" --tag=minimum');
 
         $this->line(' Publishing config for notifications - prologue/alerts');
         $this->executeProcess('php artisan vendor:publish --provider="Prologue\Alerts\AlertsServiceProvider"');

--- a/src/resources/views/inc/sidebar.blade.php
+++ b/src/resources/views/inc/sidebar.blade.php
@@ -14,6 +14,7 @@
           <!-- ================================================ -->
           <li><a href="{{ backpack_url('dashboard') }}"><i class="fa fa-dashboard"></i> <span>{{ trans('backpack::base.dashboard') }}</span></a></li>
 
+          @include('backpack::inc.sidebar_content')
 
           <!-- ======================================= -->
           {{-- <li class="header">Other menus</li> --}}

--- a/src/resources/views/inc/sidebar.blade.php
+++ b/src/resources/views/inc/sidebar.blade.php
@@ -12,7 +12,6 @@
           <!-- ================================================ -->
           <!-- ==== Recommended place for admin menu items ==== -->
           <!-- ================================================ -->
-          <li><a href="{{ backpack_url('dashboard') }}"><i class="fa fa-dashboard"></i> <span>{{ trans('backpack::base.dashboard') }}</span></a></li>
 
           @include('backpack::inc.sidebar_content')
 

--- a/src/resources/views/inc/sidebar_content.blade.php
+++ b/src/resources/views/inc/sidebar_content.blade.php
@@ -1,0 +1,1 @@
+<!-- This file is used to store sidebar items, starting with Backpack\Base 0.9.0 -->

--- a/src/resources/views/inc/sidebar_content.blade.php
+++ b/src/resources/views/inc/sidebar_content.blade.php
@@ -1,1 +1,2 @@
 <!-- This file is used to store sidebar items, starting with Backpack\Base 0.9.0 -->
+<li><a href="{{ backpack_url('dashboard') }}"><i class="fa fa-dashboard"></i> <span>{{ trans('backpack::base.dashboard') }}</span></a></li>


### PR DESCRIPTION
This makes it so that Backpack does NOT publish all views on installation. Only the minimum needed. Right now, I've deemed a new ```sidebar_content.blade.php``` file as the minimum needed.

This will allow us to:
- consider changes in blade files as non-breaking-changes, from now on;
- create a command that writes stuff in this blade file, so that the installation process adds a sidebar item automatically;