### PR TITLE
[Feature][0.9][Merged] Custom routes file + command to add to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - added command to publish only the minimum amount of files needed for Backpack to work;
 - ```sidebar_content.blade.php``` file, so that we can add sidebar items using a command
 - ```php artisan backpack:base:add-sidebar-content``` command;
+- ```php artisan backpack:base:add-custom-route``` command;
 
 ### Fixed
 - the installation command now only published the minimum amount of files, by default;

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -11,6 +11,7 @@ class BaseServiceProvider extends ServiceProvider
     protected $commands = [
         \Backpack\Base\app\Console\Commands\Install::class,
         \Backpack\Base\app\Console\Commands\AddSidebarContent::class,
+        \Backpack\Base\app\Console\Commands\AddCustomRouteContent::class,
     ];
 
     /**
@@ -26,6 +27,14 @@ class BaseServiceProvider extends ServiceProvider
      * @var string
      */
     public $routeFilePath = '/routes/backpack/base.php';
+
+
+    /**
+     * Where custom routes can be written, and will be registered by Backpack.
+     *
+     * @var string
+     */
+    public $customRoutesFilePath = '/routes/backpack/custom.php';
 
     /**
      * Perform post-registration booting of services.
@@ -55,6 +64,7 @@ class BaseServiceProvider extends ServiceProvider
 
         $this->registerAdminMiddleware($this->app->router);
         $this->setupRoutes($this->app->router);
+        $this->setupCustomRoutes($this->app->router);
         $this->publishFiles();
         $this->loadHelpers();
     }
@@ -85,6 +95,21 @@ class BaseServiceProvider extends ServiceProvider
         }
 
         $this->loadRoutesFrom($routeFilePathInUse);
+    }
+
+    /**
+     * Load custom routes file.
+     *
+     * @param \Illuminate\Routing\Router $router
+     *
+     * @return void
+     */
+    public function setupCustomRoutes(Router $router)
+    {
+        // if the custom routes file is published, register its routes
+        if (file_exists(base_path().$this->customRoutesFilePath)) {
+            $this->loadRoutesFrom(base_path().$this->customRoutesFilePath);
+        }
     }
 
     /**
@@ -139,6 +164,7 @@ class BaseServiceProvider extends ServiceProvider
 
         // sidebar_content view, which is the only view most people need to overwrite
         $backpack_sidebar_contents_view = [__DIR__.'/resources/views/inc/sidebar_content.blade.php' => resource_path('views/vendor/backpack/base/inc/sidebar_content.blade.php')];
+        $backpack_custom_routes_file = [__DIR__.$this->customRoutesFilePath => base_path($this->customRoutesFilePath)];
 
         // calculate the path from current directory to get the vendor path
         $vendorPath = dirname(__DIR__, 3);
@@ -153,6 +179,7 @@ class BaseServiceProvider extends ServiceProvider
             // $backpack_lang_files,
             $backpack_config_files,
             $backpack_sidebar_contents_view,
+            $backpack_custom_routes_file,
             $adminlte_assets,
             $gravatar_assets
         );
@@ -164,6 +191,7 @@ class BaseServiceProvider extends ServiceProvider
         $this->publishes($backpack_sidebar_contents_view, 'sidebar_content');
         $this->publishes($error_views, 'errors');
         $this->publishes($backpack_public_assets, 'public');
+        $this->publishes($backpack_custom_routes_file, 'custom_routes');
         $this->publishes($adminlte_assets, 'adminlte');
         $this->publishes($gravatar_assets, 'gravatar');
         $this->publishes($minimum, 'minimum');

--- a/src/app/Console/Commands/AddCustomRouteContent.php
+++ b/src/app/Console/Commands/AddCustomRouteContent.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Backpack\Base\app\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class AddCustomRouteContent extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:base:add-custom-route
+                                {code : HTML/PHP code that registers a route. Use either single quotes or double quotes. Never both. }';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Add HTML/PHP code to the routes/backpack/custom.php file';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $path = 'routes/backpack/custom.php';
+        $disk = Storage::disk('root');
+        $code = $this->argument('code');
+
+        if ($disk->exists($path)) {
+            $old_file_content = Storage::disk('root')->get($path);
+
+            // insert the given code before the file's last line
+            $file_lines = explode(PHP_EOL, $old_file_content);
+            $number_of_lines = count($file_lines);
+            $file_lines[$number_of_lines] = $file_lines[$number_of_lines-1];
+            $file_lines[$number_of_lines-1] = '    '.$code;
+            $new_file_content = implode(PHP_EOL, $file_lines);
+
+            if ($disk->put($path, $new_file_content)) {
+                $this->info('Successfully added code to '.$path);
+            } else {
+                $this->error('Could not write to file: '.$path);
+            }
+        } else {
+            $command = 'php artisan vendor:publish --provider="Backpack\Base\BaseServiceProvider" --tag=custom_routes';
+
+            $process = new Process($command, null, null, null, 300, null);
+
+            $process->run(function ($type, $buffer) {
+                if (Process::ERR === $type) {
+                    $this->line($buffer);
+                } else {
+                    $this->line($buffer);
+                }
+            });
+
+            // executes after the command finishes
+            if (!$process->isSuccessful()) {
+                throw new ProcessFailedException($process);
+            }
+
+            $this->handle();
+        }
+    }
+}

--- a/src/routes/backpack/custom.php
+++ b/src/routes/backpack/custom.php
@@ -9,7 +9,7 @@
 Route::group([
     'prefix'     => config('backpack.base.route_prefix', 'admin'),
     'middleware' => ['admin'],
-    'namespace'  => 'Admin',
+    'namespace'  => 'App\Http\Controllers\Admin',
 ], function () { // custom admin routes
 
 }); // this should be the absolute last line of this file

--- a/src/routes/backpack/custom.php
+++ b/src/routes/backpack/custom.php
@@ -1,0 +1,15 @@
+<?php
+
+// --------------------------
+// Custom Backpack Routes
+// --------------------------
+// This route file is loaded automatically by Backpack\Base.
+// Routes you generate using Backpack\Generators will be placed here.
+
+Route::group([
+    'prefix'     => config('backpack.base.route_prefix', 'admin'),
+    'middleware' => ['admin'],
+    'namespace'  => 'Admin',
+], function () { // custom admin routes
+
+}); // this should be the absolute last line of this file


### PR DESCRIPTION
Dependency: #252

### Feature 1

As mentioned in #253, this adds a new route file into the project folder (```routes/backpack/custom.php```). If this file is present, Backpack will register the routes present in that file.

By default, the file will be published with the default route group, but no routes:
```php
<?php

// --------------------------
// Custom Backpack Routes
// --------------------------
// This route file is loaded automatically by Backpack\Base.
// Routes you generate using Backpack\Generators will be placed here.

Route::group([
    'prefix'     => config('backpack.base.route_prefix', 'admin'),
    'middleware' => ['admin'],
    'namespace'  => 'App\Http\Controllers\Admin',
], function () { // custom admin routes

}); // this should be the absolute last line of this file
```

### Feature 2

By calling the new command ```php artisan backpack:base:add-custom-route "your-code-here"```, the argument will be placed in that custom route file, before the last line. So this is a quick way to add ```CRUD::resource();``` routes, while still being behind all needed middleware. Here's a quick demo for ```php artisan backpack:base:add-custom-route "CRUD::resource('monster', 'MonsterCrudController');"```:

![screen recording 2018-02-28 at 06 32 pm](https://user-images.githubusercontent.com/1032474/36799455-e6da12d4-1cb5-11e8-8c27-340ccdfb8c31.gif)

This will help us build a new feature in Backpack/Generators - automatically registering CRUD routes, when generating a new CRUD panel.

This is pretty fresh out of the oven - not 100% sure about the command name :-)