### PR TITLE
Add commets for default middleware

### DIFF
--- a/src/routes/backpack/custom.php
+++ b/src/routes/backpack/custom.php
@@ -8,6 +8,10 @@
 
 Route::group([
     'prefix'     => config('backpack.base.route_prefix', 'admin'),
+    // Make sure to also add your middleware here, by default it should be 'web'
+    // if you have only one session.If you have different sessions for users and admins
+    // you should use your own sessions middleware here. Example:
+    // 'middleware' => ['web', config('backpack.base.middleware_key', 'admin')],
     'middleware' => [config('backpack.base.middleware_key', 'admin')],
     'namespace'  => 'App\Http\Controllers\Admin',
 ], function () { // custom admin routes


### PR DESCRIPTION
We should better explain the default behavior here as after the upgrade to the latest version we did not know what the issue was, our routes were redirecting to /home by default.