### PR TITLE
Add the web middleware stack

### DIFF
--- a/src/routes/backpack/custom.php
+++ b/src/routes/backpack/custom.php
@@ -8,7 +8,7 @@
 
 Route::group([
     'prefix'     => config('backpack.base.route_prefix', 'admin'),
-    'middleware' => [config('backpack.base.middleware_key', 'admin')],
+    'middleware' => ['web', config('backpack.base.middleware_key', 'admin')],
     'namespace'  => 'App\Http\Controllers\Admin',
 ], function () { // custom admin routes
 }); // this should be the absolute last line of this file


### PR DESCRIPTION
Couple of people on gitter have noticed the new `custom.php` does not load the `web` middleware, so login sessions don't work.

Maybe this was an oversight or intentional?

Either way either documentation clarification is needed, or a fix in the code :)