### PR TITLE
Fix wrong function name checking

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -45,7 +45,7 @@ if (!function_exists('backpack_users_have_email')) {
     }
 }
 
-if (!function_exists('backpack_avatar')) {
+if (!function_exists('backpack_avatar_url')) {
     /**
      * Returns the avatar URL of a user.
      *


### PR DESCRIPTION
Wrong function name existence checking on declaration
Explained on #279