### PR TITLE
Removing abundant space in value attributes

### DIFF
--- a/src/resources/views/auth/account/update_info.blade.php
+++ b/src/resources/views/auth/account/update_info.blade.php
@@ -72,7 +72,7 @@
                             $field = 'name';
                         @endphp
                         <label class="required">{{ $label }}</label>
-                        <input required class="form-control" type="text" name="{{ $field }}" value="{{ old($field) ? old($field) : $user->$field }} ">
+                        <input required class="form-control" type="text" name="{{ $field }}" value="{{ old($field) ? old($field) : $user->$field }}">
                     </div>
 
                     <div class="form-group">
@@ -81,7 +81,7 @@
                             $field = backpack_authentication_column();
                         @endphp
                         <label class="required">{{ $label }}</label>
-                        <input required class="form-control" type="{{ backpack_authentication_column()=='email'?'email':'text' }}" name="{{ $field }}" value="{{ old($field) ? old($field) : $user->$field }} ">
+                        <input required class="form-control" type="{{ backpack_authentication_column()=='email'?'email':'text' }}" name="{{ $field }}" value="{{ old($field) ? old($field) : $user->$field }}">
                     </div>
 
                 </div>


### PR DESCRIPTION
Both input fields have an extra space at the end, this causes adding a space at the end of the username after each save.

Funny thing is, this issue isn't visible on the second field, if it's `type=email` as I suspect that email field trims the extra spaces. When using `type=text` though, the issue is still there.