### PR TITLE
[Feature][0.9][Ready] Added version command to output PHP, MySQL and Backpack versions

### DIFF
--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -12,6 +12,7 @@ class BaseServiceProvider extends ServiceProvider
         \Backpack\Base\app\Console\Commands\Install::class,
         \Backpack\Base\app\Console\Commands\AddSidebarContent::class,
         \Backpack\Base\app\Console\Commands\AddCustomRouteContent::class,
+        \Backpack\Base\app\Console\Commands\Version::class,
     ];
 
     /**

--- a/src/app/Console/Commands/Version.php
+++ b/src/app/Console/Commands/Version.php
@@ -40,8 +40,15 @@ class Version extends Command
      */
     public function handle()
     {
-        // $this->line(' Installing backpack/generators');
-        $command = 'php -v && composer show | grep "backpack\|laravel/framework" && mysql --version';
+        $this->comment('### PHP VERSION:');
+        $this->runCommand('php -v');
+        $this->comment('### BACKPACK PACKAGES VERSION:');
+        $this->runCommand('composer show | grep "backpack\|laravel/framework"');
+        $this->comment('### MYSQL VERSION:');
+        $this->runCommand('mysql --version');
+    }
+
+    private function runCommand($command) {
         $process = new Process($command, null, null, null, 60, null);
         $process->run(function ($type, $buffer) {
             if (Process::ERR === $type) {

--- a/src/app/Console/Commands/Version.php
+++ b/src/app/Console/Commands/Version.php
@@ -42,12 +42,20 @@ class Version extends Command
     {
         $this->comment('### PHP VERSION:');
         $this->runCommand('php -v');
+
         $this->comment('### BACKPACK PACKAGES VERSION:');
         $this->runCommand('composer show | grep "backpack\|laravel/framework"');
+
         $this->comment('### MYSQL VERSION:');
         $this->runCommand('mysql --version');
     }
 
+    /**
+     * Run a shell command in a separate process.
+     *
+     * @param  string $command Text to be executed.
+     * @return void
+     */
     private function runCommand($command) {
         $process = new Process($command, null, null, null, 60, null);
         $process->run(function ($type, $buffer) {

--- a/src/app/Console/Commands/Version.php
+++ b/src/app/Console/Commands/Version.php
@@ -52,10 +52,12 @@ class Version extends Command
     /**
      * Run a shell command in a separate process.
      *
-     * @param  string $command Text to be executed.
+     * @param string $command Text to be executed.
+     *
      * @return void
      */
-    private function runCommand($command) {
+    private function runCommand($command)
+    {
         $process = new Process($command, null, null, null, 60, null);
         $process->run(function ($type, $buffer) {
             if (Process::ERR === $type) {

--- a/src/app/Console/Commands/Version.php
+++ b/src/app/Console/Commands/Version.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Backpack\Base\app\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class Version extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:base:version';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show the version of PHP and Backpack packages.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        // $this->line(' Installing backpack/generators');
+        $command = 'php -v && composer show | grep "backpack\|laravel/framework" && mysql --version';
+        $process = new Process($command, null, null, null, 60, null);
+        $process->run(function ($type, $buffer) {
+            if (Process::ERR === $type) {
+                $this->line($buffer);
+            } else {
+                $this->line($buffer);
+            }
+        });
+
+        // executes after the command finishes
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+    }
+}


### PR DESCRIPTION
Added a new command that should help us debug stuff. If we merge this we'll be able to ask people to run ```php artisan backpack:base:version``` and copy-paste the output, which will include:
- the PHP version
- the version of all backpack & laravel packages
- the MySQL version

Credits go to @OwenMelbz and [his comment here](https://github.com/Laravel-Backpack/CRUD/issues/1539#issuecomment-404504641).

Output example:
![screen shot 2018-07-16 at 19 24 54](https://user-images.githubusercontent.com/1032474/42770921-39a49dc4-892e-11e8-95ee-0685c4f775fb.png)

[Q1] I wonder what happens if MySQL isn't installed?!