### PR TITLE
Add french canadian translation

### DIFF
--- a/src/resources/lang/fr_CA/backup.php
+++ b/src/resources/lang/fr_CA/backup.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../backupmanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../backupmanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/fr_CA/base.php
+++ b/src/resources/lang/fr_CA/base.php
@@ -1,0 +1,50 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Backpack\Base Language Lines
+    |--------------------------------------------------------------------------
+    */
+
+    'registration_closed'    => 'Inscription fermée.',
+    'first_page_you_see'     => 'La première page que vous voyez après connexion',
+    'login_status'           => 'Etat de connexion',
+    'logged_in'              => 'Vous êtes connecté!',
+    'toggle_navigation'      => 'Afficher/masquer la navigation',
+    'administration'         => 'ADMINISTRATION',
+    'user'                   => 'UTILISATEUR',
+    'logout'                 => 'Déconnexion',
+    'login'                  => 'Connexion',
+    'register'               => 'Inscription',
+    'name'                   => 'Nom',
+    'email_address'          => 'Adresse e-mail',
+    'password'               => 'Mot de passe',
+    'old_password'           => 'Ancien mot de passe',
+    'new_password'           => 'Nouveau mot de passe',
+    'confirm_password'       => 'Confirmation du mot de passe',
+    'remember_me'            => 'Se souvenir de moi',
+    'forgot_your_password'   => 'Mot de passe oublié ?',
+    'reset_password'         => 'Réinitialiser le mot de passe',
+    'send_reset_link'        => 'Envoyer un lien de réinitialisation du mot de passe',
+    'click_here_to_reset'    => 'Cliquez ici pour réinitialiser votre mot de passe',
+    'change_password'        => 'Modifier le mot de passe',
+    'unauthorized'           => 'Non autorisé.',
+    'dashboard'              => 'Tableau de bord',
+    'handcrafted_by'         => 'Artisé par',
+    'powered_by'             => 'Propulsé par',
+    'my_account'             => 'Mon compte',
+    'update_account_info'    => 'Modifier mon compte',
+    'save'                   => 'Enregistrer',
+    'cancel'                 => 'Annuler',
+    'error'                  => 'Erreur',
+    'success'                => 'Succès',
+    'old_password_incorrect' => 'L’ancien mot de passe est erroné.',
+    'password_dont_match'    => 'Les mots de passe ne correspondent pas.',
+    'password_empty'         => 'Assurez-vous de bien avoir rempli les champs de mot de passe.',
+    'password_updated'       => 'Mot de passe mis à jour.',
+    'account_updated'        => 'Compte mis à jour avec succès.',
+    'unknown_error'          => 'Un erreur s’est produite. Veuillez réessayer.',
+    'error_saving'           => 'Erreur lors de l’enregistrement. Veuillez réessayer.',
+];

--- a/src/resources/lang/fr_CA/crud.php
+++ b/src/resources/lang/fr_CA/crud.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../crud/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../crud/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/fr_CA/logmanager.php
+++ b/src/resources/lang/fr_CA/logmanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../logmanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../logmanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/fr_CA/pagemanager.php
+++ b/src/resources/lang/fr_CA/pagemanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../pagemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../pagemanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/fr_CA/permissionmanager.php
+++ b/src/resources/lang/fr_CA/permissionmanager.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../permissionmanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../permissionmanager/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];

--- a/src/resources/lang/fr_CA/settings.php
+++ b/src/resources/lang/fr_CA/settings.php
@@ -1,0 +1,16 @@
+<?php
+
+// --------------------------------------------------------
+// This is only a pointer file, not an actual language file
+// --------------------------------------------------------
+//
+// If you've copied this file to your /resources/lang/vendor/backpack/
+// folder, please delete it, it's no use there. You need to copy/publish the
+// actual language file, from the package.
+
+// If a langfile with the same name exists in the package, load that one
+if (file_exists(__DIR__.'/../../../../../settings/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__))) {
+    return include __DIR__.'/../../../../../settings/src/resources/lang/'.basename(__DIR__).'/'.basename(__FILE__);
+}
+
+return [];


### PR DESCRIPTION
This is a pull request with Translation strings for french canadien language.
I started from french translation array.
My app need to support both french and french canadian translation.
Without fr_CA folder, translation is missing in the app.