### PR TITLE
Create user command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,13 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 -------
 
 
-## [0.9.7] - 2018-08-xx
+## [0.9.7] - 2018-08-06
 
 ### Added
 - French Canadian language, thanks to @khoude24;
 - ```php artisan backpack:base:version``` command;
+- version constant on the BaseServiceProvider;
+- ```mb_ucfirst()``` helper;
 
 ### Fixed
 - #303 - custom route command;

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -8,7 +8,7 @@ use Route;
 
 class BaseServiceProvider extends ServiceProvider
 {
-    const VERSION = '0.9.6';
+    const VERSION = '0.9.7';
 
     protected $commands = [
         \Backpack\Base\app\Console\Commands\Install::class,

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -15,6 +15,7 @@ class BaseServiceProvider extends ServiceProvider
         \Backpack\Base\app\Console\Commands\AddSidebarContent::class,
         \Backpack\Base\app\Console\Commands\AddCustomRouteContent::class,
         \Backpack\Base\app\Console\Commands\Version::class,
+        \Backpack\Base\app\Console\Commands\UserCommand::class,
     ];
 
     /**

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -15,7 +15,7 @@ class BaseServiceProvider extends ServiceProvider
         \Backpack\Base\app\Console\Commands\AddSidebarContent::class,
         \Backpack\Base\app\Console\Commands\AddCustomRouteContent::class,
         \Backpack\Base\app\Console\Commands\Version::class,
-        \Backpack\Base\app\Console\Commands\UserCommand::class,
+        \Backpack\Base\app\Console\Commands\CreateUser::class,
     ];
 
     /**

--- a/src/app/Console/Commands/CreateUser.php
+++ b/src/app/Console/Commands/CreateUser.php
@@ -45,8 +45,8 @@ class CreateUser extends Command
             $password = $this->secret('Password');
         }
 
-        if(! $this->option('encrypt')) {
-          $password = bcrypt($password);
+        if (!$this->option('encrypt')) {
+            $password = bcrypt($password);
         }
 
         $auth = config('backpack.base.user_model_fqn', 'App\User');

--- a/src/app/Console/Commands/CreateUser.php
+++ b/src/app/Console/Commands/CreateUser.php
@@ -11,7 +11,7 @@ class CreateUser extends Command
      *
      * @var string
      */
-    protected $signature = 'backpack:user
+    protected $signature = 'backpack:base:user
                             {--N|name= : The name of the new user}
                             {--E|email= : The user\'s email address}
                             {--P|password= : User\'s password}
@@ -45,7 +45,7 @@ class CreateUser extends Command
             $password = $this->secret('Password');
         }
 
-        if (!$this->option('encrypt')) {
+        if ($this->option('encrypt')) {
             $password = bcrypt($password);
         }
 

--- a/src/app/Console/Commands/CreateUser.php
+++ b/src/app/Console/Commands/CreateUser.php
@@ -4,7 +4,7 @@ namespace Backpack\Base\app\Console\Commands;
 
 use Illuminate\Console\Command;
 
-class UserCommand extends Command
+class CreateUser extends Command
 {
     /**
      * The name and signature of the console command.
@@ -12,9 +12,10 @@ class UserCommand extends Command
      * @var string
      */
     protected $signature = 'backpack:user
-                            {--name= : The name of the new user}
-                            {--email= : The user\'s email address}
-                            {--password= : User\'s password}';
+                            {--N|name= : The name of the new user}
+                            {--E|email= : The user\'s email address}
+                            {--P|password= : User\'s password}
+                            {--encrypt=true : Is the user\'s password already encrypted}';
 
     /**
      * The console command description.
@@ -45,11 +46,15 @@ class UserCommand extends Command
           $password = $this->secret('Password');
         }
 
+        if(! $this->option('encrypt')) {
+          $password = bcrypt($password);
+        }
+
         $auth = config('backpack.base.user_model_fqn', 'App\User');
         $user = new $auth();
         $user->name = $name;
         $user->email = $email;
-        $user->password = bcrypt($password);
+        $user->password = $password;
 
         if($user->save()) {
           $this->info('Successfully created new user');

--- a/src/app/Console/Commands/CreateUser.php
+++ b/src/app/Console/Commands/CreateUser.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Backpack\Base\app\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class UserCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'backpack:user
+                            {--name= : The name of the new user}
+                            {--email= : The user\'s email address}
+                            {--password= : User\'s password}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new user';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+
+        $this->info('Creating a new user');
+
+        if(! $name = $this->option('name')) {
+          $name = $this->ask('Name');
+        }
+
+        if(! $email = $this->option('email')) {
+          $email = $this->ask('Email');
+        }
+
+        if(! $password = $this->option('password')) {
+          $password = $this->secret('Password');
+        }
+
+        $auth = config('backpack.base.user_model_fqn', 'App\User');
+        $user = new $auth();
+        $user->name = $name;
+        $user->email = $email;
+        $user->password = bcrypt($password);
+
+        if($user->save()) {
+          $this->info('Successfully created new user');
+        } else {
+          $this->error('Something went wrong trying to save your user');
+        }
+    }
+}


### PR DESCRIPTION
Allow the user to create a new user via console:

```
backpack:user --name=Abby --email=abby@example.com --password=mypassword
```

Features:
- If any of the options (name, email, password) are left out it will prompt for input.
- `--encrypt` option, if it should auto encrypt or not (useful for using the command within controllers to create a new user.
- option shortcuts: `N` for name, `E` for email, and `P` for password.