### PR TITLE
Update to use primary key instead of ID

### DIFF
--- a/src/app/Http/Requests/AccountInfoRequest.php
+++ b/src/app/Http/Requests/AccountInfoRequest.php
@@ -41,7 +41,7 @@ class AccountInfoRequest extends FormRequest
             backpack_authentication_column() => [
                 'required',
                 backpack_authentication_column() == 'email' ? 'email' : '',
-                Rule::unique($user->getTable())->ignore($user->getKey()),
+                Rule::unique($user->getTable())->ignore($user->getKey(),$user->getKeyName()),
             ],
             'name' => 'required',
         ];


### PR DESCRIPTION
 Rule::unique($user->getTable())->ignore($user->getKey()) 
By default uses the user table of idColumn = id. Added additional attribute of getKeyName to use the primary key defined in the user table.