### PR TITLE
[Merged] Error views are now consistent with main adminlte design

### DIFF
--- a/src/resources/error_views/400.blade.php
+++ b/src/resources/error_views/400.blade.php
@@ -1,60 +1,16 @@
-<html>
-  <head>
-    <title>{{ config('backpack.base.project_name') }} Error 400</title>
+@extends('errors.layout')
 
-    <link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+@section('error_number')
+  400
+@endsection
 
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        color: #B0BEC5;
-        display: table;
-        font-weight: 100;
-        font-family: 'Lato';
-      }
+@section('title')
+  Bad request.
+@endsection
 
-      .container {
-        text-align: center;
-        display: table-cell;
-        vertical-align: middle;
-      }
-
-      .content {
-        text-align: center;
-        display: inline-block;
-      }
-
-      .title {
-        font-size: 156px;
-      }
-
-      .quote {
-        font-size: 36px;
-      }
-
-      .explanation {
-        font-size: 24px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="content">
-        <div class="title">400</div>
-        <div class="quote">Bad request.</div>
-        <div class="explanation">
-          <br>
-          <small>
-            <?php
-              $default_error_message = "Please return to <a href='".url('')."'>our homepage</a>.";
-            ?>
-            {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
-         </small>
-       </div>
-      </div>
-    </div>
-  </body>
-</html>
+@section('description')
+  @php
+    $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
+  @endphp
+  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+@endsection

--- a/src/resources/error_views/401.blade.php
+++ b/src/resources/error_views/401.blade.php
@@ -1,60 +1,16 @@
-<html>
-  <head>
-    <title>{{ config('backpack.base.project_name') }} Error 401</title>
+@extends('errors.layout')
 
-    <link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+@section('error_number')
+  401
+@endsection
 
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        color: #B0BEC5;
-        display: table;
-        font-weight: 100;
-        font-family: 'Lato';
-      }
+@section('title')
+  Unauthorized action.
+@endsection
 
-      .container {
-        text-align: center;
-        display: table-cell;
-        vertical-align: middle;
-      }
-
-      .content {
-        text-align: center;
-        display: inline-block;
-      }
-
-      .title {
-        font-size: 156px;
-      }
-
-      .quote {
-        font-size: 36px;
-      }
-
-      .explanation {
-        font-size: 24px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="content">
-        <div class="title">401</div>
-        <div class="quote">Unauthorized action.</div>
-        <div class="explanation">
-          <br>
-          <small>
-            <?php
-              $default_error_message = "Please return to <a href='".url('')."'>our homepage</a>.";
-            ?>
-            {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
-         </small>
-       </div>
-      </div>
-    </div>
-  </body>
-</html>
+@section('description')
+  @php
+    $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
+  @endphp
+  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+@endsection

--- a/src/resources/error_views/403.blade.php
+++ b/src/resources/error_views/403.blade.php
@@ -1,60 +1,16 @@
-<html>
-  <head>
-    <title>{{ config('backpack.base.project_name') }} Error 403</title>
+@extends('errors.layout')
 
-    <link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+@section('error_number')
+  403
+@endsection
 
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        color: #B0BEC5;
-        display: table;
-        font-weight: 100;
-        font-family: 'Lato';
-      }
+@section('title')
+  Forbidden.
+@endsection
 
-      .container {
-        text-align: center;
-        display: table-cell;
-        vertical-align: middle;
-      }
-
-      .content {
-        text-align: center;
-        display: inline-block;
-      }
-
-      .title {
-        font-size: 156px;
-      }
-
-      .quote {
-        font-size: 36px;
-      }
-
-      .explanation {
-        font-size: 24px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="content">
-        <div class="title">403</div>
-        <div class="quote">Forbidden.</div>
-        <div class="explanation">
-          <br>
-          <small>
-            <?php
-              $default_error_message = "Please return to <a href='".url('')."'>our homepage</a>.";
-            ?>
-            {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
-         </small>
-       </div>
-      </div>
-    </div>
-  </body>
-</html>
+@section('description')
+  @php
+    $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
+  @endphp
+  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+@endsection

--- a/src/resources/error_views/404.blade.php
+++ b/src/resources/error_views/404.blade.php
@@ -1,60 +1,16 @@
-<html>
-  <head>
-    <title>{{ config('backpack.base.project_name') }} Error 404</title>
+@extends('errors.layout')
 
-    <link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+@section('error_number')
+  404
+@endsection
 
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        color: #B0BEC5;
-        display: table;
-        font-weight: 100;
-        font-family: 'Lato';
-      }
+@section('title')
+  Page not found.
+@endsection
 
-      .container {
-        text-align: center;
-        display: table-cell;
-        vertical-align: middle;
-      }
-
-      .content {
-        text-align: center;
-        display: inline-block;
-      }
-
-      .title {
-        font-size: 156px;
-      }
-
-      .quote {
-        font-size: 36px;
-      }
-
-      .explanation {
-        font-size: 24px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="content">
-        <div class="title">404</div>
-        <div class="quote">Page not found.</div>
-        <div class="explanation">
-          <br>
-          <small>
-            <?php
-              $default_error_message = "Please return to <a href='".url('')."'>our homepage</a>.";
-            ?>
-            {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
-         </small>
-       </div>
-      </div>
-    </div>
-  </body>
-</html>
+@section('description')
+  @php
+    $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
+  @endphp
+  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+@endsection

--- a/src/resources/error_views/405.blade.php
+++ b/src/resources/error_views/405.blade.php
@@ -1,60 +1,16 @@
-<html>
-  <head>
-    <title>{{ config('backpack.base.project_name') }} Error 405</title>
+@extends('errors.layout')
 
-    <link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+@section('error_number')
+  405
+@endsection
 
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        color: #B0BEC5;
-        display: table;
-        font-weight: 100;
-        font-family: 'Lato';
-      }
+@section('title')
+  Method not allowed.
+@endsection
 
-      .container {
-        text-align: center;
-        display: table-cell;
-        vertical-align: middle;
-      }
-
-      .content {
-        text-align: center;
-        display: inline-block;
-      }
-
-      .title {
-        font-size: 156px;
-      }
-
-      .quote {
-        font-size: 36px;
-      }
-
-      .explanation {
-        font-size: 24px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="content">
-        <div class="title">405</div>
-        <div class="quote">Method not allowed.</div>
-        <div class="explanation">
-          <br>
-          <small>
-            <?php
-              $default_error_message = "Please return to <a href='".url('')."'>our homepage</a>.";
-            ?>
-            {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
-         </small>
-       </div>
-      </div>
-    </div>
-  </body>
-</html>
+@section('description')
+  @php
+    $default_error_message = "Please <a href='javascript:history.back()''>go back</a> or return to <a href='".url('')."'>our homepage</a>.";
+  @endphp
+  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+@endsection

--- a/src/resources/error_views/408.blade.php
+++ b/src/resources/error_views/408.blade.php
@@ -1,60 +1,17 @@
-<html>
-  <head>
-    <title>{{ config('backpack.base.project_name') }} Error 408</title>
+@extends('errors.layout')
 
-    <link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+@section('error_number')
+  408
+@endsection
 
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        color: #B0BEC5;
-        display: table;
-        font-weight: 100;
-        font-family: 'Lato';
-      }
+@section('title')
+  Request timeout.
+@endsection
 
-      .container {
-        text-align: center;
-        display: table-cell;
-        vertical-align: middle;
-      }
+@section('description')
+  @php
+    $default_error_message = "Please <a href='javascript:history.back()''>go back</a>, refresh the page and tru again.";
 
-      .content {
-        text-align: center;
-        display: inline-block;
-      }
-
-      .title {
-        font-size: 156px;
-      }
-
-      .quote {
-        font-size: 36px;
-      }
-
-      .explanation {
-        font-size: 24px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="content">
-        <div class="title">408</div>
-        <div class="quote">Request timeout.</div>
-        <div class="explanation">
-          <br>
-          <small>
-            <?php
-              $default_error_message = "Please return to <a href='".url('')."'>our homepage</a>.";
-            ?>
-            {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
-         </small>
-       </div>
-      </div>
-    </div>
-  </body>
-</html>
+  @endphp
+  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+@endsection

--- a/src/resources/error_views/429.blade.php
+++ b/src/resources/error_views/429.blade.php
@@ -1,60 +1,16 @@
-<html>
-  <head>
-    <title>{{ config('backpack.base.project_name') }} Error 429</title>
+@extends('errors.layout')
 
-    <link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+@section('error_number')
+  429
+@endsection
 
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        color: #B0BEC5;
-        display: table;
-        font-weight: 100;
-        font-family: 'Lato';
-      }
+@section('title')
+  Too many requests.
+@endsection
 
-      .container {
-        text-align: center;
-        display: table-cell;
-        vertical-align: middle;
-      }
-
-      .content {
-        text-align: center;
-        display: inline-block;
-      }
-
-      .title {
-        font-size: 156px;
-      }
-
-      .quote {
-        font-size: 36px;
-      }
-
-      .explanation {
-        font-size: 24px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="content">
-        <div class="title">429</div>
-        <div class="quote">Too many requests.</div>
-        <div class="explanation">
-          <br>
-          <small>
-            <?php
-              $default_error_message = "Please return to <a href='".url('')."'>our homepage</a>.";
-            ?>
-            {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
-         </small>
-       </div>
-      </div>
-    </div>
-  </body>
-</html>
+@section('description')
+  @php
+    $default_error_message = "Please <a href='javascript:history.back()''>go back</a> and try again, or return to <a href='".url('')."'>our homepage</a>.";
+  @endphp
+  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+@endsection

--- a/src/resources/error_views/500.blade.php
+++ b/src/resources/error_views/500.blade.php
@@ -1,60 +1,16 @@
-<html>
-  <head>
-    <title>{{ config('backpack.base.project_name') }} Error 500</title>
+@extends('errors.layout')
 
-    <link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+@section('error_number')
+	500
+@endsection
 
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        color: #B0BEC5;
-        display: table;
-        font-weight: 100;
-        font-family: 'Lato';
-      }
+@section('title')
+	It's not you, it's me.
+@endsection
 
-      .container {
-        text-align: center;
-        display: table-cell;
-        vertical-align: middle;
-      }
-
-      .content {
-        text-align: center;
-        display: inline-block;
-      }
-
-      .title {
-        font-size: 156px;
-      }
-
-      .quote {
-        font-size: 36px;
-      }
-
-      .explanation {
-        font-size: 24px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="content">
-        <div class="title">500</div>
-        <div class="quote">It's not you, it's me.</div>
-        <div class="explanation">
-          <br>
-          <small>
-            <?php
-              $default_error_message = "An internal server error has occurred. If the error persists please contact the development team.";
-            ?>
-            {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
-         </small>
-       </div>
-      </div>
-    </div>
-  </body>
-</html>
+@section('description')
+	@php
+	  $default_error_message = "An internal server error has occurred. If the error persists please contact the development team.";
+	@endphp
+	{!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+@endsection

--- a/src/resources/error_views/503.blade.php
+++ b/src/resources/error_views/503.blade.php
@@ -1,60 +1,16 @@
-<html>
-  <head>
-    <title>{{ config('backpack.base.project_name') }} Error 503</title>
+@extends('errors.layout')
 
-    <link href='//fonts.googleapis.com/css?family=Lato:100' rel='stylesheet' type='text/css'>
+@section('error_number')
+  503
+@endsection
 
-    <style>
-      body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        height: 100%;
-        color: #B0BEC5;
-        display: table;
-        font-weight: 100;
-        font-family: 'Lato';
-      }
+@section('title')
+  It's not you, it's me.
+@endsection
 
-      .container {
-        text-align: center;
-        display: table-cell;
-        vertical-align: middle;
-      }
-
-      .content {
-        text-align: center;
-        display: inline-block;
-      }
-
-      .title {
-        font-size: 156px;
-      }
-
-      .quote {
-        font-size: 36px;
-      }
-
-      .explanation {
-        font-size: 24px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <div class="content">
-        <div class="title">503</div>
-        <div class="quote">It's not you, it's me.</div>
-        <div class="explanation">
-          <br>
-          <small>
-            <?php
-              $default_error_message = "The server is overloaded or down for maintenance. Please try again later.";
-            ?>
-            {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
-         </small>
-       </div>
-      </div>
-    </div>
-  </body>
-</html>
+@section('description')
+  @php
+    $default_error_message = "The server is overloaded or down for maintenance. Please try again later.";
+  @endphp
+  {!! isset($exception)? ($exception->getMessage()?$exception->getMessage():$default_error_message): $default_error_message !!}
+@endsection

--- a/src/resources/error_views/layout.blade.php
+++ b/src/resources/error_views/layout.blade.php
@@ -12,7 +12,7 @@
         height: 100%;
         color: #B0BEC5;
         display: table;
-        font-weight: 100;
+        font-weight: 400;
         font-family: 'Source Sans Pro', sans-serif;
         background-color: #ecf0f5;
       }
@@ -29,8 +29,7 @@
       }
 
       .error_number {
-        font-size: 156px;
-        font-weight: 400;
+        font-size: 196px;
       }
 
       .title {
@@ -38,7 +37,7 @@
       }
 
       .description {
-        font-size: 24px;
+        font-size: 22px;
       }
     </style>
   </head>

--- a/src/resources/error_views/layout.blade.php
+++ b/src/resources/error_views/layout.blade.php
@@ -1,0 +1,63 @@
+<html>
+  <head>
+    <title>{{ config('backpack.base.project_name') }} Error @yield('error_number')</title>
+
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        height: 100%;
+        color: #B0BEC5;
+        display: table;
+        font-weight: 100;
+        font-family: 'Source Sans Pro', sans-serif;
+        background-color: #ecf0f5;
+      }
+
+      .container {
+        text-align: center;
+        display: table-cell;
+        vertical-align: middle;
+      }
+
+      .content {
+        text-align: center;
+        display: inline-block;
+      }
+
+      .error_number {
+        font-size: 156px;
+        font-weight: 400;
+      }
+
+      .title {
+        font-size: 36px;
+      }
+
+      .description {
+        font-size: 24px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="content">
+        <div class="error_number">
+          @yield('error_number')
+        </div>
+        <div class="title">
+          @yield('title')
+        </div>
+        <div class="description">
+          <br>
+          <small>
+            @yield('description')
+         </small>
+       </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
- changes error views to use a layout, so it’s easier to customize the design for all error pages
- changes default error views design background, font and color to match AdminLTE

Before:
![screenshot 2018-10-30 at 10 01 36](https://user-images.githubusercontent.com/1032474/47704051-f9a6de80-dc2a-11e8-889e-a31f6fd55b7f.png)

After:
![screenshot 2018-10-30 at 09 58 09](https://user-images.githubusercontent.com/1032474/47704054-fdd2fc00-dc2a-11e8-9369-8e824811d602.png)
