### PR TITLE
[4.0][Ready] Parental upgrade to 0.6 (the single table inheritance package)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "prologue/alerts": "^0.4.1",
         "jenssegers/date": "^3.2",
         "creativeorange/gravatar": "~1.0",
-        "tightenco/parental": "0.5"
+        "tightenco/parental": "0.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/src/app/Models/BackpackUser.php
+++ b/src/app/Models/BackpackUser.php
@@ -4,11 +4,11 @@ namespace Backpack\Base\app\Models;
 
 use App\User;
 use Backpack\Base\app\Notifications\ResetPasswordNotification as ResetPasswordNotification;
-use Tightenco\Parental\HasParentModel;
+use Tightenco\Parental\HasParent;
 
 class BackpackUser extends User
 {
-    use HasParentModel;
+    use HasParent;
 
     protected $table = 'users';
 


### PR DESCRIPTION
0.6 of https://github.com/tightenco/parental has been released with several big bug fixes and enhancements to the single table inheritance implementation

This is a breaking change as the name of the Trait has changed in 0.6.

From HasParentModel to HasParent