### PR TITLE
[WIP] Laravel 5.8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,30 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 -------
 
+## [1.1.0] - 2019-03-01
+
+### Added
+- Laravel 5.8 support;
+
+### Fixed
+- Bootstrap was forced to upgrade to 3.4.1 by using a CDN, so that everyone gets the new XSS security vulnerability fix, and the upgrade process is smooth;
+
+### Removed
+- ```Tightenco\Parental``` dependency; the trait we were using is now included as ```Backpack\Base\app\Models\Traits\InheritsRelationsFromParentModel;```;
+
+**Upgrade guide:**
+- Upgrade to Laravel 5.8 or do ```composer require backpack/base:"1.1.*"
+- in your ```App\Models\BackpackUser``` instead of ```Tightenco\Parental\HasParent```, please use ```Backpack\Base\app\Models\Traits\InheritsRelationsFromParentModel```; [here's the diff](https://github.com/Laravel-Backpack/Base/pull/362/files#diff-f075b83ebb2b1ef3ba84dec14b395607);
+- if you've overwritten ```inc/head.blade.php``` or ```inc/scripts.blade.php```, please make sure you [use the newest version of Bootstrap](https://github.com/Laravel-Backpack/Base/pull/362/files#diff-96ac3ea4d0cb85053acf44e3772eb5f1); they've fixed a security vulnerability (XSS);
+
+
+----
+
+## [1.0.4] - 2018-12-10
+
+### Fixed
+- Portuguese translation;
+
 
 ## [1.0.4] - 2018-12-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,6 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 - Portuguese translation;
 
 
-## [1.0.4] - 2018-12-10
-
-### Fixed
-- Portuguese translation;
-
-
 ## [1.0.3] - 2018-12-06
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
         "almasaeed2010/adminlte" : "~2.4",
         "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
-        "creativeorange/gravatar": "~1.0",
-        "tightenco/parental": "^0.6.1"
+        "creativeorange/gravatar": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "almasaeed2010/AdminLTE" : "2.4.*",
+        "almasaeed2010/AdminLTE" : "2.4.9^",
         "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "almasaeed2010/adminlte" : "2.4.*",
         "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
-        "creativeorange/gravatar": "~1.0",
-        "jenssegers/date": "^3.2"
+        "jenssegers/date": "^3.2",
+        "creativeorange/gravatar": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
         "jenssegers/date": "^3.2",
-        "creativeorange/gravatar": "~1.0",
-        "tightenco/parental": "0.6"
+        "creativeorange/gravatar": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "almasaeed2010/AdminLTE" : "2.4.*",
-        "laravel/framework": "5.6.*|5.7.*",
+        "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
         "jenssegers/date": "^3.2",
         "creativeorange/gravatar": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "prologue/alerts": "^0.4.1",
         "jenssegers/date": "^3.2",
         "creativeorange/gravatar": "~1.0",
-        "tightenco/parental": "0.5"
+        "tightenco/parental": "0.6"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "almasaeed2010/adminlte" : "~2.4",
         "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
-        "creativeorange/gravatar": "~1.0"
+        "creativeorange/gravatar": "~1.0",
+        "tightenco/parental": "^0.6.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "almasaeed2010/AdminLTE" : "^2.4.9",
+        "almasaeed2010/AdminLTE" : ">=2.4.9",
         "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "almasaeed2010/adminlte" : "~2.4",
+        "almasaeed2010/adminlte" : ">=2.4.9",
         "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "almasaeed2010/adminlte" : "~2.4",
-        "laravel/framework": "5.6.*|5.7.*|5.8.*",
+        "laravel/framework": "5.8.*",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "almasaeed2010/AdminLTE" : "2.4.*",
         "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
-        "jenssegers/date": "^3.2",
         "creativeorange/gravatar": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "almasaeed2010/adminlte" : ">=2.4.9",
+        "almasaeed2010/adminlte" : "~2.4",
         "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "almasaeed2010/AdminLTE" : "2.4.9^",
+        "almasaeed2010/AdminLTE" : "^2.4.9",
         "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0"

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,11 @@
         }
     ],
     "require": {
-        "almasaeed2010/adminlte" : "~2.4",
-        "laravel/framework": "5.8.*",
+        "almasaeed2010/adminlte" : "2.4.*",
+        "laravel/framework": "5.6.*|5.7.*|5.8.*",
         "prologue/alerts": "^0.4.1",
-        "creativeorange/gravatar": "~1.0"
+        "creativeorange/gravatar": "~1.0",
+        "jenssegers/date": "^3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",

--- a/src/BaseServiceProvider.php
+++ b/src/BaseServiceProvider.php
@@ -176,14 +176,12 @@ class BaseServiceProvider extends ServiceProvider
         $this->loadHelpers();
 
         // register its dependencies
-        $this->app->register(\Jenssegers\Date\DateServiceProvider::class);
         $this->app->register(\Prologue\Alerts\AlertsServiceProvider::class);
         $this->app->register(\Creativeorange\Gravatar\GravatarServiceProvider::class);
 
         // register their aliases
         $loader = \Illuminate\Foundation\AliasLoader::getInstance();
         $loader->alias('Alert', \Prologue\Alerts\Facades\Alert::class);
-        $loader->alias('Date', \Jenssegers\Date\Date::class);
         $loader->alias('Gravatar', \Creativeorange\Gravatar\Facades\Gravatar::class);
 
         // register the services that are only used for development

--- a/src/app/Console/Commands/PublishBackpackUserModel.php
+++ b/src/app/Console/Commands/PublishBackpackUserModel.php
@@ -77,7 +77,7 @@ class PublishBackpackUserModel extends GeneratorCommand
      */
     protected function makeReplacements(&$stub)
     {
-        $stub = str_replace('Backpack\Base\app\Models', $this->laravel->getNamespace().'Models', $stub);
+        $stub = str_replace('Backpack\Base\app\Models;', $this->laravel->getNamespace().'Models;', $stub);
 
         if (!$this->files->exists($this->laravel['path'].'/User.php') && $this->files->exists($this->laravel['path'].'/Models/User.php')) {
             $stub = str_replace($this->laravel->getNamespace().'User', $this->laravel->getNamespace().'Models\User', $stub);

--- a/src/app/Models/BackpackUser.php
+++ b/src/app/Models/BackpackUser.php
@@ -4,11 +4,11 @@ namespace Backpack\Base\app\Models;
 
 use App\User;
 use Backpack\Base\app\Notifications\ResetPasswordNotification as ResetPasswordNotification;
-use Tightenco\Parental\HasParentModel;
+// use Tightenco\Parental\HasParentModel;
 
 class BackpackUser extends User
 {
-    use HasParentModel;
+    // use HasParentModel;
 
     protected $table = 'users';
 

--- a/src/app/Models/BackpackUser.php
+++ b/src/app/Models/BackpackUser.php
@@ -4,9 +4,12 @@ namespace Backpack\Base\app\Models;
 
 use App\User;
 use Backpack\Base\app\Notifications\ResetPasswordNotification as ResetPasswordNotification;
+use Backpack\Base\app\Models\Traits\InheritsRelationsFromParentModel;
 
 class BackpackUser extends User
 {
+    use InheritsRelationsFromParentModel;
+
     protected $table = 'users';
 
     /**

--- a/src/app/Models/BackpackUser.php
+++ b/src/app/Models/BackpackUser.php
@@ -3,8 +3,8 @@
 namespace Backpack\Base\app\Models;
 
 use App\User;
-use Backpack\Base\app\Notifications\ResetPasswordNotification as ResetPasswordNotification;
 use Backpack\Base\app\Models\Traits\InheritsRelationsFromParentModel;
+use Backpack\Base\app\Notifications\ResetPasswordNotification as ResetPasswordNotification;
 
 class BackpackUser extends User
 {

--- a/src/app/Models/Traits/InheritsRelationsFromParentModel.php
+++ b/src/app/Models/Traits/InheritsRelationsFromParentModel.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Backpack\Base\app\Models\Traits;
+
+use Illuminate\Support\Str;
+use ReflectionClass;
+
+/**
+ * This trait helps a child model (ex: BackpackUser) inherit all relationships of its parent model (ex: User).
+ * Laravel by default doesn't do that, so packages like Backpack\PermissionManager can't see relationships
+ * on the BackpackUser model, because they haven't been inherited from User.
+ *
+ * The code below has been copy-pasted from https://github.com/tightenco/parental on Feb 27th 2019.
+ * When they provide support for Laravel 5.8, this entire trait could go away (or load their trait).
+ */
+trait InheritsRelationsFromParentModel
+{
+    public $hasParent = true;
+
+    public static function bootHasParent()
+    {
+        static::creating(function ($model) {
+            if ($model->parentHasHasChildrenTrait()) {
+                $model->forceFill(
+                    [$model->getInheritanceColumn() => $model->classToAlias(get_class($model))]
+                );
+            }
+        });
+        static::addGlobalScope(function ($query) {
+            $instance = new static;
+            if ($instance->parentHasHasChildrenTrait()) {
+                $query->where($instance->getInheritanceColumn(), $instance->classToAlias(get_class($instance)));
+            }
+        });
+    }
+
+    public function parentHasHasChildrenTrait()
+    {
+        return $this->hasChildren ?? false;
+    }
+
+    public function getTable()
+    {
+        if (! isset($this->table)) {
+            return str_replace('\\', '', Str::snake(Str::plural(class_basename($this->getParentClass()))));
+        }
+        return $this->table;
+    }
+
+    public function getForeignKey()
+    {
+        return Str::snake(class_basename($this->getParentClass())).'_'.$this->primaryKey;
+    }
+
+    public function joiningTable($related, $instance = null)
+    {
+        $relatedClassName = method_exists((new $related), 'getClassNameForRelationships')
+            ? (new $related)->getClassNameForRelationships()
+            : class_basename($related);
+        $models = [
+            Str::snake($relatedClassName),
+            Str::snake($this->getClassNameForRelationships()),
+        ];
+        sort($models);
+        return strtolower(implode('_', $models));
+    }
+
+    public function getClassNameForRelationships()
+    {
+        return class_basename($this->getParentClass());
+    }
+
+    public function getMorphClass()
+    {
+        if ($this->parentHasHasChildrenTrait()) {
+            $parentClass = $this->getParentClass();
+            return (new $parentClass)->getMorphClass();
+        }
+        return parent::getMorphClass();
+    }
+
+    protected function getParentClass()
+    {
+        static $parentClassName;
+        return $parentClassName ?: $parentClassName = (new ReflectionClass($this))->getParentClass()->getName();
+    }
+}

--- a/src/app/Models/Traits/InheritsRelationsFromParentModel.php
+++ b/src/app/Models/Traits/InheritsRelationsFromParentModel.php
@@ -27,7 +27,7 @@ trait InheritsRelationsFromParentModel
             }
         });
         static::addGlobalScope(function ($query) {
-            $instance = new static;
+            $instance = new static();
             if ($instance->parentHasHasChildrenTrait()) {
                 $query->where($instance->getInheritanceColumn(), $instance->classToAlias(get_class($instance)));
             }
@@ -41,9 +41,10 @@ trait InheritsRelationsFromParentModel
 
     public function getTable()
     {
-        if (! isset($this->table)) {
+        if (!isset($this->table)) {
             return str_replace('\\', '', Str::snake(Str::plural(class_basename($this->getParentClass()))));
         }
+
         return $this->table;
     }
 
@@ -54,14 +55,15 @@ trait InheritsRelationsFromParentModel
 
     public function joiningTable($related, $instance = null)
     {
-        $relatedClassName = method_exists((new $related), 'getClassNameForRelationships')
-            ? (new $related)->getClassNameForRelationships()
+        $relatedClassName = method_exists((new $related()), 'getClassNameForRelationships')
+            ? (new $related())->getClassNameForRelationships()
             : class_basename($related);
         $models = [
             Str::snake($relatedClassName),
             Str::snake($this->getClassNameForRelationships()),
         ];
         sort($models);
+
         return strtolower(implode('_', $models));
     }
 
@@ -74,14 +76,17 @@ trait InheritsRelationsFromParentModel
     {
         if ($this->parentHasHasChildrenTrait()) {
             $parentClass = $this->getParentClass();
-            return (new $parentClass)->getMorphClass();
+
+            return (new $parentClass())->getMorphClass();
         }
+
         return parent::getMorphClass();
     }
 
     protected function getParentClass()
     {
         static $parentClassName;
+
         return $parentClassName ?: $parentClassName = (new ReflectionClass($this))->getParentClass()->getName();
     }
 }

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -31,9 +31,9 @@ return [
     'skin' => 'skin-purple',
     // Options: skin-black, skin-blue, skin-purple, skin-red, skin-yellow, skin-green, skin-blue-light, skin-black-light, skin-purple-light, skin-green-light, skin-red-light, skin-yellow-light
 
-    // Date & Datetime default formats (in ISO format, same as Carbon and Moment.js)
-    'default_date_format'     => 'Do MMMM YYYY',
-    'default_datetime_format' => 'Do MMMM YYYY, HH:mm',
+    // Date & Datetime Format Syntax: https://github.com/jenssegers/date#usage
+    'default_date_format'     => 'j F Y',
+    'default_datetime_format' => 'j F Y H:i',
 
     // Content of the HTML meta robots tag to prevent indexing and link following
     'meta_robots_content' => 'noindex, nofollow',

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -31,9 +31,9 @@ return [
     'skin' => 'skin-purple',
     // Options: skin-black, skin-blue, skin-purple, skin-red, skin-yellow, skin-green, skin-blue-light, skin-black-light, skin-purple-light, skin-green-light, skin-red-light, skin-yellow-light
 
-    // Date & Datetime Format
-    'default_date_format'     => 'j F Y',
-    'default_datetime_format' => 'j F Y H:i',
+    // Date & Datetime default formats (in ISO format, same as Carbon and Moment.js)
+    'default_date_format'     => 'Do MMMM YYYY',
+    'default_datetime_format' => 'Do MMMM YYYY, HH:mm',
 
     // Content of the HTML meta robots tag to prevent indexing and link following
     'meta_robots_content' => 'noindex, nofollow',

--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -31,8 +31,7 @@ return [
     'skin' => 'skin-purple',
     // Options: skin-black, skin-blue, skin-purple, skin-red, skin-yellow, skin-green, skin-blue-light, skin-black-light, skin-purple-light, skin-green-light, skin-red-light, skin-yellow-light
 
-    // Date & Datetime Format Syntax: https://github.com/jenssegers/date#usage
-    // (same as Carbon)
+    // Date & Datetime Format
     'default_date_format'     => 'j F Y',
     'default_datetime_format' => 'j F Y H:i',
 

--- a/src/resources/views/inc/head.blade.php
+++ b/src/resources/views/inc/head.blade.php
@@ -16,8 +16,8 @@
 @stack('before_styles')
 
 <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
-<!-- Bootstrap 3.3.7 -->
-<link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/bower_components/bootstrap/dist/css/bootstrap.min.css">
+<!-- Bootstrap 3.4.1 -->
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css" integrity="sha384-HSMxcRTRxnN+Bdg0JdbxYKrThecOKuH5zCYotlSAcp1+c8xmyTe9GYg1l9a69psu" crossorigin="anonymous">
 <link rel="stylesheet" href="{{ asset('vendor/adminlte/') }}/bower_components/font-awesome/css/font-awesome.min.css">
 <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
 

--- a/src/resources/views/inc/scripts.blade.php
+++ b/src/resources/views/inc/scripts.blade.php
@@ -3,8 +3,8 @@
 {{-- <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
 <script>window.jQuery || document.write('<script src="{{ asset('vendor/adminlte') }}/bower_components/jquery/dist/jquery.min.js"><\/script>')</script> --}}
 
-<!-- Bootstrap 3.3.7 -->
-<script src="{{ asset('vendor/adminlte') }}/bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
+<!-- Bootstrap 3.4.1 -->
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
 <script src="{{ asset('vendor/adminlte') }}/plugins/pace/pace.min.js"></script>
 <script src="{{ asset('vendor/adminlte') }}/bower_components/jquery-slimscroll/jquery.slimscroll.min.js"></script>
 {{-- <script src="{{ asset('vendor/adminlte') }}/bower_components/fastclick/lib/fastclick.js"></script> --}}


### PR DESCRIPTION
This branch and PR will provide support for Laravel 5.8.

[TLDR here](https://github.com/Laravel-Backpack/Base/pull/362#issuecomment-468563782).

Todo:
- [x] require laravel 5.8 in composer.json
- [x] remove tightenco/parental dependency - since it does not yet support Laravel 5.8, I got the change to take another look at it; it look like we're only using it in conjunction with PermissionManager, so it makes no sense to force this dependency in Backpack/Base; We should do so in PermissionManager, and instruct users to add this to their BackpackUser model upon installation;
- [x] update or remove jenssegers/date dependency;
- [x] upgrade to nesbot/carbon v2; Note: reverted to carbon v1;
- [x] (maybe) bump adminlte dependency Note: was impossible; adminlte respository is now broken for most users;
- [x] upgrade bootstrap dependency to have recent fix to XSS vulnerability

Official packages TODOs:
- [x] Confirm / add L5.8 support to Backpack\PermissionManager;
- [x] Confirm / add L5.8 support to Backpack\Generators;
- [x] Confirm / add L5.8 support to Backpack\Settings;
- [x] Confirm / add L5.8 support to Backpack\PageManager;
- [ ] Confirm / add L5.8 support to Backpack\BackupManager;
- [x] Confirm / add L5.8 support to Backpack\LogManager;
- [x] Confirm / add L5.8 support to Backpack\LangFileManager;
- [x] Confirm / add L5.8 support to Backpack\MenuCRUD;
- [x] Confirm / add L5.8 support to Backpack\NewsCRUD;
- [ ] upgrade Demo to Laravel 5.8;
- [ ] write and publish upgrade guide;
- [ ] send newsletter;