### PR TITLE
Shorter default date display and link to Carbon docs instead

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -31,9 +31,9 @@ return [
     'skin' => 'skin-purple',
     // Options: skin-black, skin-blue, skin-purple, skin-red, skin-yellow, skin-green, skin-blue-light, skin-black-light, skin-purple-light, skin-green-light, skin-red-light, skin-yellow-light
 
-    // Date & Datetime Format Syntax: https://github.com/jenssegers/date#usage
-    'default_date_format'     => 'Do MMMM YYYY',
-    'default_datetime_format' => 'Do MMMM YYYY, HH:mm',
+    // Date & Datetime Format Syntax: https://carbon.nesbot.com/docs/#api-localization
+    'default_date_format'     => 'D MMM YYYY',
+    'default_datetime_format' => 'D MMM YYYY, HH:mm',
 
     // Content of the HTML meta robots tag to prevent indexing and link following
     'meta_robots_content' => 'noindex, nofollow',


### PR DESCRIPTION
The reference table is under localization section of Carbon docs

https://carbon.nesbot.com/docs/#api-localization

I also shorten the date format from

```
'default_date_format'     => 'Do MMMM YYYY',
'default_datetime_format' => 'Do MMMM YYYY, HH:mm',
```

```
'default_date_format'     => 'D MMM YYYY',
'default_datetime_format' => 'D MMM YYYY, HH:mm',
```

Because 11 Sept 2019 is shorter than 11th September 2019. Which for admin views is almost always better given the number of table columns in a limited screen space. Allowing 1-3 more columns to show without hiding