### PR TITLE
[4.0][Feature][Needs cleanup and polish] Use CoreUI and Bootstrap 4 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,12 @@ php artisan backpack:base:install
 
 3) [optional] Change values in config/backpack/base.php to make the admin panel your own. Change menu color, project name, developer name etc.
 
-## Upgrading from Laravel 5.7 to Laravel 5.8 (or from Base 1.0 to Base 1.1)
-- Upgrade to Laravel 5.8; you might need to change your ```backpack/crud``` dependency to ```3.6.*``` in your ```composer.json```;
-- in your ```App\Models\BackpackUser``` instead of ```Tightenco\Parental\HasParent```, please use ```Backpack\Base\app\Models\Traits\InheritsRelationsFromParentModel```; [here's the diff](https://github.com/Laravel-Backpack/Base/pull/362/files#diff-f075b83ebb2b1ef3ba84dec14b395607);
-- in your ```app/config/backpack/base.php``` please change your ```default_date_format``` and ```default_datetime_format``` to ```Do MMMM YYYY``` and ```Do MMMM YYYY, HH:mm``` respectively;
-- if you've overwritten ```inc/head.blade.php``` or ```inc/scripts.blade.php```, please make sure you [use the newest version of Bootstrap](https://github.com/Laravel-Backpack/Base/pull/362/files#diff-96ac3ea4d0cb85053acf44e3772eb5f1); they've fixed a security vulnerability (XSS);
+## TODO: Upgrading from Base 1.1 to Base 2.0
+- Make sure you're running Base 1.1 and CRUD 3.6; If not, follow the upgrade guides to reach those versions;
+- Upgrade to Laravel 6.0; 
+- Change your ```backpack/crud``` dependency to ```4.*``` in your ```composer.json```;
+- more
+- even more
 
 
 ## Usage 


### PR DESCRIPTION
Similar design to the 3.4 revamp, but using CoreUI instead of AdminLTE. I found this CoreUI was the only free Bootstrap 4 Admin Panel HTML Theme that was easy to work with, and provided a reasonable amount of building blocks (basically all of Bootstrap's plus a sidebar). And trust me, it took MONTHS to take this decision. In the process, I've tried the top 5 free admin panel themes, and even got to implement like 80% of the features for 2 of them (AdminLTE v3 and Tabler). But they each had stuff that annoyed me. I consider the HTML theme you're working with very _very_ important in admin panels, so I decided to scrap weeks of work and start again. Fortunately CoreUI is a keeper, in my opinion.

However, I found its default design underwhelming, so I went ahead and layered my design preferences on top of CoreUI. The result is [Backstrap](https://github.com/DigitallyHappy/BackStrap), a free HTML template that I hope more people will use, even outside of Laravel.

![Screenshot 2019-06-21 at 11 49 34](https://user-images.githubusercontent.com/1032474/59910730-2e1a1580-941b-11e9-81a6-5f8398217e96.jpg)
![Screenshot 2019-06-21 at 11 50 12](https://user-images.githubusercontent.com/1032474/59910720-2c505200-941b-11e9-8ae1-162e083c304e.jpg)
![Screenshot 2019-06-21 at 11 50 01](https://user-images.githubusercontent.com/1032474/59910726-2ce8e880-941b-11e9-9c82-99af8e8a4304.jpg)
