### PR TITLE
[4.0][Feature][Ready] Ability to show/hide breadcrumbs

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -31,6 +31,10 @@ return [
     'skin' => 'skin-purple',
     // Options: skin-black, skin-blue, skin-purple, skin-red, skin-yellow, skin-green, skin-blue-light, skin-black-light, skin-purple-light, skin-green-light, skin-red-light, skin-yellow-light
 
+    // Breadcrumbs
+    // Show / hide breadcrumbs on admin panel pages.
+    'breadcrumbs' => true,
+
     // Date & Datetime Format Syntax: https://carbon.nesbot.com/docs/#api-localization
     'default_date_format'     => 'D MMM YYYY',
     'default_datetime_format' => 'D MMM YYYY, HH:mm',

--- a/src/resources/views/auth/account/change_password.blade.php
+++ b/src/resources/views/auth/account/change_password.blade.php
@@ -12,6 +12,7 @@
 @section('header')
 <section class="content-header">
 
+    @if (config('backpack.base.breadcrumbs'))
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
@@ -19,6 +20,7 @@
         <li class="breadcrumb-item active" aria-current="page">{{ trans('backpack::base.change_password') }}</li>
       </ol>
     </nav>
+    @endif
 
     <div class="container-fluid"><h1>{{ trans('backpack::base.my_account') }}</h1></div>
 

--- a/src/resources/views/auth/account/update_info.blade.php
+++ b/src/resources/views/auth/account/update_info.blade.php
@@ -12,6 +12,7 @@
 @section('header')
 <section class="content-header">
 
+    @if (config('backpack.base.breadcrumbs'))
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
@@ -19,6 +20,7 @@
         <li class="breadcrumb-item active" aria-current="page">{{ trans('backpack::base.update_account_info') }}</li>
       </ol>
     </nav>
+    @endif
 
     <div class="container-fluid"><h1>{{ trans('backpack::base.my_account') }}</h1></div>
 

--- a/src/resources/views/dashboard.blade.php
+++ b/src/resources/views/dashboard.blade.php
@@ -1,12 +1,14 @@
 @extends('backpack::layout')
 
 @section('header')
+    @if (config('backpack.base.breadcrumbs'))
     <nav aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
         <li class="breadcrumb-item active" aria-current="page">{{ trans('backpack::base.dashboard') }}</li>
       </ol>
     </nav>
+    @endif
     <section class="container-fluid">
       <h1>
         <span class="text-capitalize">{{ trans('backpack::base.dashboard') }}</small>


### PR DESCRIPTION
Allows you to hide all breadcrumbs across the admin panel.
Or show them. Not sure which one should be the default :-)

Requires the CoreUI branch to be merged first.

![Screenshot 2019-06-24 at 11 57 57](https://user-images.githubusercontent.com/1032474/60005529-5f8f1d00-9677-11e9-922a-821af3caea2d.jpg)
![Screenshot 2019-06-24 at 11 58 12](https://user-images.githubusercontent.com/1032474/60005531-6027b380-9677-11e9-906f-5cf9ecffe6e7.jpg)
