### PR TITLE
Sync with tightenco/parental latest bug fixes

### DIFF
--- a/src/app/Models/Traits/InheritsRelationsFromParentModel.php
+++ b/src/app/Models/Traits/InheritsRelationsFromParentModel.php
@@ -10,13 +10,11 @@ use ReflectionClass;
  * Laravel by default doesn't do that, so packages like Backpack\PermissionManager can't see relationships
  * on the BackpackUser model, because they haven't been inherited from User.
  *
- * The code below has been copy-pasted from https://github.com/tightenco/parental on Feb 27th 2019.
- * When they provide support for Laravel 5.8, this entire trait could go away (or load their trait).
+ * The code below has been copy-pasted from https://github.com/tightenco/parental on Jul 19th 2019.
  */
 trait InheritsRelationsFromParentModel
 {
     public $hasParent = true;
-
     public static function bootHasParent()
     {
         static::creating(function ($model) {
@@ -27,66 +25,54 @@ trait InheritsRelationsFromParentModel
             }
         });
         static::addGlobalScope(function ($query) {
-            $instance = new static();
+            $instance = new static;
             if ($instance->parentHasHasChildrenTrait()) {
-                $query->where($instance->getInheritanceColumn(), $instance->classToAlias(get_class($instance)));
+                $query->where($instance->getTable().'.'.$instance->getInheritanceColumn(), $instance->classToAlias(get_class($instance)));
             }
         });
     }
-
     public function parentHasHasChildrenTrait()
     {
         return $this->hasChildren ?? false;
     }
-
     public function getTable()
     {
-        if (!isset($this->table)) {
+        if (! isset($this->table)) {
             return str_replace('\\', '', Str::snake(Str::plural(class_basename($this->getParentClass()))));
         }
-
         return $this->table;
     }
-
     public function getForeignKey()
     {
         return Str::snake(class_basename($this->getParentClass())).'_'.$this->primaryKey;
     }
-
     public function joiningTable($related, $instance = null)
     {
-        $relatedClassName = method_exists((new $related()), 'getClassNameForRelationships')
-            ? (new $related())->getClassNameForRelationships()
+        $relatedClassName = method_exists((new $related), 'getClassNameForRelationships')
+            ? (new $related)->getClassNameForRelationships()
             : class_basename($related);
         $models = [
             Str::snake($relatedClassName),
             Str::snake($this->getClassNameForRelationships()),
         ];
         sort($models);
-
         return strtolower(implode('_', $models));
     }
-
     public function getClassNameForRelationships()
     {
         return class_basename($this->getParentClass());
     }
-
     public function getMorphClass()
     {
         if ($this->parentHasHasChildrenTrait()) {
             $parentClass = $this->getParentClass();
-
-            return (new $parentClass())->getMorphClass();
+            return (new $parentClass)->getMorphClass();
         }
-
         return parent::getMorphClass();
     }
-
     protected function getParentClass()
     {
         static $parentClassName;
-
         return $parentClassName ?: $parentClassName = (new ReflectionClass($this))->getParentClass()->getName();
     }
 }


### PR DESCRIPTION
That package got updated again with some fixes. This PR simply copy over the changes.

This trait now support 5.8 so you may load their trait or merge this if you think they won't be updated fast enough for the upcoming 5.9.