### PR TITLE
[4.0][Feature][Ready] Ability to add/change breadcrumbs from Controller or View

### DIFF
--- a/src/resources/views/auth/account/change_password.blade.php
+++ b/src/resources/views/auth/account/change_password.blade.php
@@ -9,22 +9,18 @@
 </style>
 @endsection
 
+@php
+  $breadcrumbs = [
+      trans('backpack::crud.admin') => url(config('backpack.base.route_prefix'), 'dashboard'),
+      trans('backpack::base.my_account') => route('backpack.account.info'),
+      trans('backpack::base.change_password') => false,
+  ];
+@endphp
+
 @section('header')
-<section class="content-header">
-
-    @if (config('backpack.base.breadcrumbs'))
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
-        <li class="breadcrumb-item"><a href="{{ route('backpack.account.info') }}">{{ trans('backpack::base.my_account') }}</a></li>
-        <li class="breadcrumb-item active" aria-current="page">{{ trans('backpack::base.change_password') }}</li>
-      </ol>
-    </nav>
-    @endif
-
-    <div class="container-fluid"><h1>{{ trans('backpack::base.my_account') }}</h1></div>
-
-</section>
+    <section class="content-header">
+        <div class="container-fluid"><h1>{{ trans('backpack::base.my_account') }}</h1></div>
+    </section>
 @endsection
 
 @section('content')

--- a/src/resources/views/auth/account/update_info.blade.php
+++ b/src/resources/views/auth/account/update_info.blade.php
@@ -9,22 +9,18 @@
 </style>
 @endsection
 
+@php
+  $breadcrumbs = [
+      trans('backpack::crud.admin') => url(config('backpack.base.route_prefix'), 'dashboard'),
+      trans('backpack::base.my_account') => route('backpack.account.info'),
+      trans('backpack::base.update_account_info') => false,
+  ];
+@endphp
+
 @section('header')
-<section class="content-header">
-
-    @if (config('backpack.base.breadcrumbs'))
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
-        <li class="breadcrumb-item"><a href="{{ route('backpack.account.info') }}">{{ trans('backpack::base.my_account') }}</a></li>
-        <li class="breadcrumb-item active" aria-current="page">{{ trans('backpack::base.update_account_info') }}</li>
-      </ol>
-    </nav>
-    @endif
-
-    <div class="container-fluid"><h1>{{ trans('backpack::base.my_account') }}</h1></div>
-
-</section>
+    <section class="content-header">
+        <div class="container-fluid"><h1>{{ trans('backpack::base.my_account') }}</h1></div>
+    </section>
 @endsection
 
 @section('content')

--- a/src/resources/views/dashboard.blade.php
+++ b/src/resources/views/dashboard.blade.php
@@ -1,15 +1,11 @@
 @extends('backpack::layout')
 
-@section('header')
-    @if (config('backpack.base.breadcrumbs'))
-    <nav aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item"><a href="{{ url(config('backpack.base.route_prefix'), 'dashboard') }}">{{ trans('backpack::crud.admin') }}</a></li>
-        <li class="breadcrumb-item active" aria-current="page">{{ trans('backpack::base.dashboard') }}</li>
-      </ol>
-    </nav>
-    @endif
-@endsection
+@php
+  $breadcrumbs = [
+      trans('backpack::crud.admin') => url(config('backpack.base.route_prefix'), 'dashboard'),
+      trans('backpack::base.dashboard') => false,
+  ];
+@endphp
 
 @section('content')
     <div class="jumbotron">

--- a/src/resources/views/inc/breadcrumbs.blade.php
+++ b/src/resources/views/inc/breadcrumbs.blade.php
@@ -3,9 +3,9 @@
 	  <ol class="breadcrumb">
 	  	@foreach ($breadcrumbs as $label => $link)
 	  		@if ($link)
-			    <li class="breadcrumb-item"><a href="{{ $link }}">{{ $label }}</a></li>
+			    <li class="breadcrumb-item text-capitalize"><a href="{{ $link }}">{{ $label }}</a></li>
 	  		@else
-			    <li class="breadcrumb-item active" aria-current="page">{{ $label }}</li>
+			    <li class="breadcrumb-item text-capitalize active" aria-current="page">{{ $label }}</li>
 	  		@endif
 	  	@endforeach
 	  </ol>

--- a/src/resources/views/inc/breadcrumbs.blade.php
+++ b/src/resources/views/inc/breadcrumbs.blade.php
@@ -1,0 +1,13 @@
+@if (config('backpack.base.breadcrumbs') && isset($breadcrumbs) && is_array($breadcrumbs) && count($breadcrumbs))
+	<nav aria-label="breadcrumb">
+	  <ol class="breadcrumb">
+	  	@foreach ($breadcrumbs as $label => $link)
+	  		@if ($link)
+			    <li class="breadcrumb-item"><a href="{{ $link }}">{{ $label }}</a></li>
+	  		@else
+			    <li class="breadcrumb-item active" aria-current="page">{{ $label }}</li>
+	  		@endif
+	  	@endforeach
+	  </ol>
+	</nav>
+@endif

--- a/src/resources/views/layout.blade.php
+++ b/src/resources/views/layout.blade.php
@@ -17,6 +17,8 @@
 
     <main class="main">
 
+       @includeWhen(isset($breadcrumbs), 'backpack::inc.breadcrumbs')
+       
        @yield('header')
 
         <div class="container-fluid animated fadeIn">


### PR DESCRIPTION
[Documentation here](https://backpackforlaravel.com/docs/4.0/base-how-to#use-breadcrumbs).

The gist of it is that you can now define breadcrumbs using a simple associative array (label => link), from anywhere you want. When the page is loaded, if a ```$breadcrumbs``` variable is present, the breadcrumbs will be shown.

You can do this from a view:
```php
@php
  $breadcrumbs = [
      trans('backpack::crud.admin') => url(config('backpack.base.route_prefix'), 'dashboard'),
      trans('backpack::base.my_account') => route('backpack.account.info'),
      trans('backpack::base.update_account_info') => false,
  ];
@endphp
```

Or this from a controller:
```php
    /**
     * Show the admin dashboard.
     *
     * @return \Illuminate\Http\Response
     */
    public function dashboard()
    {
        $this->data['title'] = trans('backpack::base.dashboard'); // set the page title
        $this->data['breadcrumbs'] = [
            trans('backpack::crud.admin') => url(config('backpack.base.route_prefix'), 'dashboard'),
            trans('backpack::base.dashboard') => false,
        ];

        return view('backpack::dashboard', $this->data);
    }
```

Also, since the breadcrumbs now live in their own blade file, developers can easily overwrite them.