### PR TITLE
Adds a configurable middleware group for the base routes

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -68,6 +68,9 @@ return [
     // You can make sure all your URLs use this prefix by using the backpack_url() helper instead of url()
     'route_prefix' => 'admin',
 
+    // The middleware (group) used in all base routes
+    'route_middleware' => 'web',
+
     // Set this to false if you would like to use your own AuthController and PasswordController
     // (you then need to setup your auth routes manually in your routes.php file)
     'setup_auth_routes' => true,

--- a/src/routes/backpack/base.php
+++ b/src/routes/backpack/base.php
@@ -13,7 +13,7 @@
 Route::group(
 [
     'namespace'  => 'Backpack\Base\app\Http\Controllers',
-    'middleware' => 'web',
+    'middleware' => config('backpack.base.route_middleware'),
     'prefix'     => config('backpack.base.route_prefix'),
 ],
 function () {


### PR DESCRIPTION
This pull request adds the functionality to make the middleware of the default routes configurable. In my case this is needed because my web middleware is already used by an other part of the application. 