### PR TITLE
Updated base.php - Fixed spelling mistakes

### DIFF
--- a/src/config/backpack/base.php
+++ b/src/config/backpack/base.php
@@ -122,7 +122,7 @@ return [
 
     // All JS and CSS assets defined above have this string appended as query string (?v=string).
     // If you want to manually trigger cachebusting for all styles and scripts,
-    // append or prepent something to the string below, so that it's different.
+    // append or prepend something to the string below, so that it's different.
     'cachebusting_string' => \PackageVersions\Versions::getVersion('backpack/base'),
 
     /*
@@ -171,7 +171,7 @@ return [
     'user_model_fqn' => App\Models\BackpackUser::class,
 
     // The classes for the middleware to check if the visitor is an admin
-    // Can be a single class or an array of clases
+    // Can be a single class or an array of classes
     'middleware_class' => [
         App\Http\Middleware\CheckIfAdmin::class,
         \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,


### PR DESCRIPTION
Fixed spelling mistakes in base.php

clases to classes
prepent to prepend