### PR TITLE
Add Support for latest laravel versions (7.x, 8.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "almasaeed2010/adminlte" : "2.4.*",
-        "laravel/framework": "5.8.*|^6.0",
+        "laravel/framework": "5.8.*|^6.0|^7.0|^8.0",
         "prologue/alerts": "^0.4.1",
         "creativeorange/gravatar": "~1.0",
         "nesbot/carbon": "^2.14.0",


### PR DESCRIPTION
This PR's purpose is to add compatibility for `backpack/base` onto latest releases of Laravel 7.x and 8.x

Change involves `composer.json`'s package list, akin to the last PR involving a Laravel upgrade  (#403)